### PR TITLE
I got `tdl` added to `Scoop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ sudo mv tdl /usr/bin
 Move-Item tdl.exe C:\Windows\System32
 ```
 
+Install with a package manager
+```shell
+# Scoop (Windows) https://scoop.sh/#/apps?s=2&d=1&o=true&p=1&q=telegram+downloader
+scoop bucket add extras
+scoop install telegram-downloader
+```
+
 ## Quick Start
 
 ```shell


### PR DESCRIPTION
Hello @iyear, I got **tdl** added to [Scoop](https://scoop.sh/#/apps?s=2&d=1&o=true&p=1&q=telegram+downloader) as `telegram-downloader`. If you don't know what Scoop is, it's a package manager for Windows.

Scoop can be installed into your Windows OS by following the instructions [here](https://scoop.sh/). After Scoop is installed in your system, you can install **telegram-downloader** with the following commands.

_First Command_
```
scoop bucket add extras
```
_Second Command_
```
scoop install telegram-downloader
```