### PR TITLE
Issue 86: DL Resume

### DIFF
--- a/app/dl/iter.go
+++ b/app/dl/iter.go
@@ -256,17 +256,6 @@ func (i *iter) item(ctx context.Context, peer tg.InputPeerClass, msg int) (*down
 	return media, nil
 }
 
-/* func (i *iter) CheckResumeForCompleted(_ context.Context) bool {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-
-	total := 0
-	for _, m := range i.dialogs {
-		total += len(m.msgs)
-	}
-	return total
-} */
-
 func (i *iter) Total(_ context.Context) int {
 	i.mu.Lock()
 	defer i.mu.Unlock()

--- a/app/dl/iter.go
+++ b/app/dl/iter.go
@@ -5,6 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sync"
+	"text/template"
+	"time"
+
 	"github.com/gotd/td/telegram/peers"
 	"github.com/gotd/td/telegram/query"
 	"github.com/gotd/td/tg"
@@ -13,10 +18,6 @@ import (
 	"github.com/iyear/tdl/pkg/kv"
 	"github.com/iyear/tdl/pkg/storage"
 	"github.com/iyear/tdl/pkg/utils"
-	"path/filepath"
-	"sync"
-	"text/template"
-	"time"
 )
 
 type iter struct {
@@ -129,6 +130,12 @@ func (i *iter) item(ctx context.Context, peer tg.InputPeerClass, msg int) (*down
 	if message.ID != msg {
 		return nil, fmt.Errorf("msg may be deleted, id: %d", msg)
 	}
+
+	// Check If message has been successfully downloaded and skip
+	//if CheckResumableForCompleted(message.ID) {
+	//	return nil, fmt.Errorf("msg already completed downloaded, id: %d", msg)
+	//  return nil, downloader.ErrSkip   // Prob choose this one as it wont log according to downloader.go
+	//}
 
 	media, ok := GetMedia(message)
 	if !ok {

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/fatih/color"
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/gotd/td/telegram/downloader"
@@ -12,10 +17,6 @@ import (
 	"github.com/iyear/tdl/pkg/utils"
 	"github.com/jedib0t/go-pretty/v6/progress"
 	"golang.org/x/sync/errgroup"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 const TempExt = ".tmp"
@@ -154,6 +155,13 @@ func (d *Downloader) download(ctx context.Context, item *Item) error {
 	if err = os.Rename(path, filepath.Join(d.dir, newfile)); err != nil {
 		return err
 	}
+
+	// Write to resumable file. Do we need a mutex for concurrent access?
+	//
+	//os.OpenFile()
+	//
+	//
+	//
 
 	return nil
 }

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -20,6 +20,7 @@ import (
 )
 
 const TempExt = ".tmp"
+const ResExt = ".tgresume"
 
 var formatter = utils.Byte.FormatBinaryBytes
 
@@ -110,7 +111,7 @@ func (d *Downloader) download(ctx context.Context, item *Item) error {
 	default:
 	}
 
-	name := replacer.Replace(item.Name)
+	name := replacer.Replace(item.Name) // tmp file finished writing here and is bein renamed to templayedname
 	if d.skipSame {
 		if stat, err := os.Stat(filepath.Join(d.dir, name)); err == nil {
 			if utils.FS.GetNameWithoutExt(name) == utils.FS.GetNameWithoutExt(stat.Name()) &&
@@ -156,12 +157,18 @@ func (d *Downloader) download(ctx context.Context, item *Item) error {
 		return err
 	}
 
-	// Write to resumable file. Do we need a mutex for concurrent access?
-	//
-	//os.OpenFile()
-	//
-	//
-	//
+	// open tgresumefile
+	// Write completed MessageID to the tgresume file.
+	resfile := fmt.Sprintf("%d%s", item.ChatID, ResExt)
+
+	f2, err := os.OpenFile(resfile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, os.ModeAppend|0644)
+	if err != nil {
+		return err
+	}
+
+	f2.WriteString(fmt.Sprintf("%d\n", item.MsgID))
+	f2.Sync()
+	f2.Close()
 
 	return nil
 }

--- a/pkg/downloader/iter.go
+++ b/pkg/downloader/iter.go
@@ -3,6 +3,7 @@ package downloader
 import (
 	"context"
 	"errors"
+
 	"github.com/gotd/td/tg"
 )
 
@@ -18,4 +19,6 @@ type Item struct {
 	Name         string
 	Size         int64
 	DC           int
+	ChatID       int64
+	MsgID        int
 }


### PR DESCRIPTION
Hello,

This is partial implementation for Enhancment #86  for resuming on the `dl` subcmd processer. 
This is a PRELIMINARY WORK_IN_PROGRESS (hence debug comments and few old code that I can get additional eyes and assistance from more experience Gophers) 

So at this stage it is only for your testing and to see if such API changes is allowable. It worked under my limited testing but we would need further clarification on some matters.

Currently:
 - Changes are in iter.go and downloader.go. However, would there be preferred location that changes should be cohabitated?
 -  Resume files are called `.tgresume` they are created in the base directory of the launch. No specified paths unlike the `-f` flag. I think that can be supported as an extra flag or we can use the path supplied to `-f` but that requires a signature change on a few functions
 - Currrently, I just use the Chat/Room ID for the name of the `.tgresume` file. Ideally, if above is allowable it would take the export file and append the .tgresume (ie something like tdl-export.tgresume)
 -  The tgresume file is just individual messageID integers delimited by newlines. It should probably in my opinion follow the exact json format that td-export.json uses. I dont see much of difference. Although, I didnt want to import the json module at this time.


Caveats:
- Somethings were done a bit oddly because I didnt want to/dont know if itll bloat up the binary by importing a few packages. So you'll see that things like using `sprintf` to create filenames or using `bufio` instead of a simple `scanner`. As well as not importing the json module as mentioned above
- Only tested in my private channel.
- I need to add many more code comments so I can clarify that later and intend to give better variable names and yadda yadda
- This was my first time looking at something related to MTPROTO and the code was confusing for me (esp as some of the synonyms between the specification and colloquial usage). Though I think the `mm` variable in iter.go has the ability to get multiple "chats/rooms/channels". I only tested with one channel at a time.
