### PR TITLE
Add macOS package manager for installation

### DIFF
--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -74,7 +74,13 @@ scoop install telegram-downloader
 
 {{< /tab >}}
 {{< tab "MacOS" >}}
-Contributions are welcome!
+
+#### Homebrew
+
+{{< command >}}
+brew install telegram-downloader
+{{< /command >}}
+
 {{< /tab >}}
 {{< tab "Linux" >}}
 Contributions are welcome!

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -73,7 +73,13 @@ scoop install telegram-downloader
 
 {{< /tab >}}
 {{< tab "MacOS" >}}
-欢迎贡献！
+
+#### Homebrew
+
+{{< command >}}
+brew install telegram-downloader
+{{< /command >}}
+
 {{< /tab >}}
 {{< tab "Linux" >}}
 欢迎贡献！


### PR DESCRIPTION
I've added it to [homebrew](https://github.com/Homebrew/brew#homebrew)'s [default package index](https://github.com/Homebrew/homebrew-core/blob/master/Formula/t/telegram-downloader.rb).

Homebrew is a popular package manager tool for macOS (and Linux). With current configuration, it will download tdl from [source](https://github.com/iyear/tdl/archive/refs/tags/v0.12.1.tar.gz) and compile it for distribution.

I'm working on automatically updating the version as new releases come out.