### PR TITLE
fix(download): Consider if a template specifies a sub directory

### DIFF
--- a/app/dl/progress.go
+++ b/app/dl/progress.go
@@ -95,7 +95,7 @@ func (p *progress) donePost(elem *iterElem) error {
 		}
 	}
 
-	if err := os.Rename(elem.to.Name(), filepath.Join(p.opts.Dir, newfile)); err != nil {
+	if err := os.Rename(elem.to.Name(), filepath.Join(filepath.Dir(elem.to.Name()), newfile)); err != nil {
 		return errors.Wrap(err, "rename file")
 	}
 


### PR DESCRIPTION
I specified a template that specified a subdirectory for downloads and the files seemed to revert back to the download directory. This fixes it.