### PR TITLE
fix(tpath): Add possibly desktop data path for Linux

### DIFF
--- a/pkg/tpath/tpath_linux.go
+++ b/pkg/tpath/tpath_linux.go
@@ -26,6 +26,7 @@ func desktopAppData(homedir string) []string {
 		// https://github.com/iyear/tdl/issues/92#issuecomment-1699307412
 		filepath.Join(prefix, "KotatogramDesktop"),
 		filepath.Join(prefix, "64Gram"),
+		filepath.Join(prefix, "TelegramDesktop"),
 	)
 
 	if t, err := filepath.Glob("~/snap/telegram-desktop/*/.local/share/TelegramDesktop"); err == nil {


### PR DESCRIPTION
`~/.local/share/TelegramDesktop` is also a possible path to store telegram data. Tested on Ubuntu22.04 LTS with the latest Telegram Desktop (v4.16.8).