### PR TITLE
docs(hugo): fixed small typo in 'export messages'

### DIFF
--- a/docs/content/en/guide/tools/export-messages.md
+++ b/docs/content/en/guide/tools/export-messages.md
@@ -102,7 +102,7 @@ tdl chat export -c CHAT -T last -i 10 -f "Views>200 && Media.Name endsWith '.zip
 Export with message content:
 
 {{< command >}}
-tdl chat -c CHAT --with-content
+tdl chat export -c CHAT --with-content
 {{< /command >}}
 
 ## Raw

--- a/docs/content/zh/guide/tools/export-messages.md
+++ b/docs/content/zh/guide/tools/export-messages.md
@@ -102,7 +102,7 @@ tdl chat export -c CHAT -T last -i 10 -f "Views>200 && Media.Name endsWith '.zip
 附带消息内容：
 
 {{< command >}}
-tdl chat -c CHAT --with-content
+tdl chat export -c CHAT --with-content
 {{< /command >}}
 
 ## 原始数据


### PR DESCRIPTION
Fixed a small typo in documentation here https://docs.iyear.me/tdl/guide/tools/export-messages/. 
The `export` sub-command was missed for "Export with message content".