### PR TITLE
Feature: Download all media from single message containing multiple files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ downloads
 *.exe
 tdl
 .hugo_build.lock
+*.DS_Store

--- a/app/dl/iter.go
+++ b/app/dl/iter.go
@@ -38,6 +38,7 @@ type fileTemplate struct {
 	FileCaption  string
 	FileSize     string
 	DownloadDate int64
+	GroupIndex   int
 }
 
 type iter struct {
@@ -196,6 +197,7 @@ func (i *iter) processSingle(message *tg.Message, from peers.Peer) (bool, bool) 
 		FileCaption:  message.Message,
 		FileSize:     utils.Byte.FormatBinaryBytes(item.Size),
 		DownloadDate: time.Now().Unix(),
+		GroupIndex:   0,
 	})
 	if err != nil {
 		i.err = errors.Wrap(err, "execute template")


### PR DESCRIPTION
Some messages might have multiple pictures and/or videos. This feature adds the ability to download all pictures and videos from one message, simply enter the message url like normal and it downloads all media in that message instead of just the last one, which was the case at least on macOS. Thanks, hope it helps out, this is an awesome utility \m/