### PR TITLE
feat(template): add MaxLength argument to filenamify method

### DIFF
--- a/docs/content/en/guide/template.md
+++ b/docs/content/en/guide/template.md
@@ -38,7 +38,7 @@ Template syntax is based on [Go's text/template](https://golang.org/pkg/text/tem
 |    `rand`    |                                      Generate random number in range `MIN` to `MAX`                                      |                        `rand MIN MAX`                        |                                   `{{ rand 1 10 }}`                                   |
 |    `now`     |                                                  Get current timestamp                                                   |                            `now`                             |                                      `{{ now }}`                                      |
 | `formatDate` | Format `TIMESTAMP` with [format](https://golang.cafe/blog/golang-time-format-example.html)<br/>Default: `20060102150405` | `formatDate TIMESTAMP` <br/> `formatDate TIMESTAMP "format"` | `{{ formatDate 1600000000 }}`<br/> `{{ formatDate 1600000000 "2006-01-02-15-04-05"}}` |
-| `filenamify` |                                Convert `STRING` to a valid filename with the best effort.                                |                     `filenamify STRING`                      |                             `{{ filenamify .FileName }}`                              |
+| `filenamify` |    Convert `STRING` to a valid filename with the best effort. Optional `MaxLength` can be used to limit string length    |                 `filenamify STRING MaxLength`                |                           `{{ filenamify .FileName 32 }}`                             |
 
 ### Examples:
 

--- a/docs/content/zh/guide/template.md
+++ b/docs/content/zh/guide/template.md
@@ -38,7 +38,7 @@ bookToC: false
 |    `rand`    |                                  在范围 `MIN` 到 `MAX` 生成随机数                                   |                        `rand MIN MAX`                        |                                   `{{ rand 1 10 }}`                                   |
 |    `now`     |                                          获取当前时间戳                                           |                            `now`                             |                                      `{{ now }}`                                      |
 | `formatDate` | [格式化](https://zhuanlan.zhihu.com/p/145009400) `TIMESTAMP` 时间戳<br/>(默认格式: `20060102150405`) | `formatDate TIMESTAMP` <br/> `formatDate TIMESTAMP "format"` | `{{ formatDate 1600000000 }}`<br/> `{{ formatDate 1600000000 "2006-01-02-15-04-05"}}` |
-| `filenamify` |                                   尽可能将 `STRING` 转换为合法文件名                                   |                     `filenamify STRING`                      |                             `{{ filenamify .FileName }}`                              |
+| `filenamify` |            尽可能将 `STRING` 转换为合法文件名，可选 `MaxLength` 限制字符串长度避免文件系统限制   |                   `filenamify STRING MaxLength`                 |                             `{{ filenamify .FileName 32 }}`                             |
 
 ### 示例：
 

--- a/pkg/tplfunc/string.go
+++ b/pkg/tplfunc/string.go
@@ -69,8 +69,15 @@ func KebabCase() Func {
 
 func Filenamify() Func {
 	return func(funcMap template.FuncMap) {
-		funcMap["filenamify"] = func(s string) string {
-			res, err := filenamify.FilenamifyV2(s)
+		funcMap["filenamify"] = func(s string, maxLength ...int) string {
+			if len(maxLength) > 1 {
+				return "invalid-MaxLength"
+			}
+			res, err := filenamify.FilenamifyV2(s, func(options *filenamify.Options) {
+				if len(maxLength) > 0 {
+					options.MaxLength = maxLength[0]
+				}
+			})
 			if err != nil || res == "" {
 				return "invalid-filename"
 			}


### PR DESCRIPTION
When using `{{ .FileCaption }}` in filename templates, some long caption would cause download failure due to file system length limit.

So I add a second optional argument to `filenamify` method, to limit string length to a value that would not exceed the limit.