### PR TITLE
Check for non-empty messages before accessing lastMsg

### DIFF
--- a/app/chat/ls.go
+++ b/app/chat/ls.go
@@ -277,8 +277,10 @@ func fetchTopics(ctx context.Context, api *tg.Client, c tg.InputChannelClass) ([
 			break
 		}
 
-		if lastMsg, ok := topics.Messages[len(topics.Messages)-1].AsNotEmpty(); ok {
-			offsetID, offsetDate = lastMsg.GetID(), lastMsg.GetDate()
+		if len(topics.Messages) > 0 {
+			if lastMsg, ok := topics.Messages[len(topics.Messages)-1].AsNotEmpty(); ok {
+				offsetID, offsetDate = lastMsg.GetID(), lastMsg.GetDate()
+			}
 		}
 	}
 


### PR DESCRIPTION
The code is trying to access topics.Messages[len(topics.Messages)-1] without checking if topics.Messages is empty. When topics.Messages has length 0, len(topics.Messages)-1 becomes -1, which causes a panic.

The issue occurs when:

There are more topics to fetch (len(topics.Topics) >= limit), but topics.Messages is empty (no messages in this batch)

I added a simple check to fix the glitch.