### PR TITLE
feat: add flag to download messages only after a given timestamp

### DIFF
--- a/app/chat/export.go
+++ b/app/chat/export.go
@@ -34,6 +34,7 @@ type ExportOptions struct {
 	Input       []int
 	Output      string
 	Filter      string
+	AfterDate   int
 	OnlyMedia   bool
 	WithContent bool
 	Raw         bool
@@ -173,6 +174,12 @@ loop:
 		if !ok {
 			continue
 		}
+
+		// Stop if message date is older than AfterDate threshold
+		if opts.AfterDate > 0 && m.Date < opts.AfterDate {
+			break loop
+		}
+
 		// only get media messages
 		media, ok := tmedia.GetMedia(m)
 		if !ok && !opts.All {

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -104,6 +104,7 @@ func NewChatExport() *cobra.Command {
 
 	cmd.Flags().IntSliceVarP(&opts.Input, input, "i", []int{}, "input data, depends on export type")
 	cmd.Flags().StringVarP(&opts.Filter, "filter", "f", "true", "filter messages by expression, defaults to match all messages. Specify '-' to see available fields")
+	cmd.Flags().IntVar(&opts.AfterDate, "after-date", 0, "only return messages after the provided timestamp")
 	cmd.Flags().StringVarP(&opts.Output, "output", "o", "tdl-export.json", "output JSON file path")
 	cmd.Flags().BoolVar(&opts.WithContent, "with-content", false, "export with message content")
 	cmd.Flags().BoolVar(&opts.Raw, "raw", false, "export raw message struct of Telegram MTProto API, useful for debugging")


### PR DESCRIPTION
This change adds flag `--after-date` to only download messages after a provided timestamp. This is useful to avoid iterating the whole chat history when you only want to download new messages.