### PR TITLE
Implement fallback for fetching dialogs in batches

### DIFF
--- a/app/chat/ls.go
+++ b/app/chat/ls.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/expr-lang/expr"
+	"github.com/fatih/color"
 	"github.com/go-faster/errors"
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/telegram/message/peer"
@@ -513,8 +514,9 @@ func fetchDialogsWithErrorHandling(ctx context.Context, api *tg.Client) ([]dialo
 						}
 					} else {
 						// Can't continue pagination without access hash
-						log.Warn("failed to get user for offset, stopping pagination",
+						log.Error("failed to get user for offset, stopping pagination",
 							zap.Int64("user_id", peerType.UserID))
+						color.Red("Error: failed to get user for offset, stopping pagination. User ID: %d", peerType.UserID)
 						return allElems, skipped
 					}
 				case *tg.PeerChat:
@@ -527,8 +529,9 @@ func fetchDialogsWithErrorHandling(ctx context.Context, api *tg.Client) ([]dialo
 						}
 					} else {
 						// Can't continue pagination without access hash
-						log.Warn("failed to get channel for offset, stopping pagination",
+						log.Error("failed to get channel for offset, stopping pagination",
 							zap.Int64("channel_id", peerType.ChannelID))
+						color.Red("Error: failed to get channel for offset, stopping pagination. Channel ID: %d", peerType.ChannelID)
 						return allElems, skipped
 					}
 				}


### PR DESCRIPTION
Added a fallback mechanism for fetching dialogs with smaller batches if the initial attempt fails. This improves error handling for inaccessible or deleted channels.

I'm not familiar with the design approach behind the application, whether we want to fail partially or fail horribly when there is an issue with either a batch rate limitation or a broken channel, but this is something that worked for me when facing:
  - channel [number] not found:
    github.com/gotd/td/telegram/message/peer.Entities.ExtractPeer
        C:/Users/psymon/go/pkg/mod/github.com/gotd/td@v0.122.0/telegram/message/peer/extract.go:129

Which I think is the case for #713 

Feel free to throw away if you don't find it useful or at least back burner a better approach ¯\_(ツ)_/¯

close #713