### PR TITLE
add direct download support for channels, groups, and topics

### DIFF
--- a/app/dl/dl.go
+++ b/app/dl/dl.go
@@ -39,12 +39,21 @@ type Options struct {
 	Takeout    bool
 	Group      bool // auto detect grouped message
 
+	// chat-based download
+	Chat     string
+	Topic    int
+	MsgStart int
+	MsgEnd   int
+
 	// resume opts
 	Continue, Restart bool
 
 	// serve
 	Serve bool
 	Port  int
+
+	// html export for text messages
+	SaveHTML bool
 }
 
 type parser struct {
@@ -62,12 +71,50 @@ func Run(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts Opti
 		{Data: opts.URLs, Parser: tmessage.FromURL(ctx, pool, kvd, opts.URLs)},
 		{Data: opts.Files, Parser: tmessage.FromFile(ctx, pool, kvd, opts.Files, true)},
 	}
+
+	// Add chat-based parser if --chat is specified
+	if opts.Chat != "" {
+		parsers = append(parsers, parser{
+			Data:   []string{opts.Chat},
+			Parser: tmessage.FromChat(ctx, pool, kvd, opts.Chat, opts.Topic, opts.MsgStart, opts.MsgEnd),
+		})
+	}
 	dialogs, err := collectDialogs(parsers)
 	if err != nil {
 		return err
 	}
 	logctx.From(ctx).Debug("Collect dialogs",
 		zap.Any("dialogs", dialogs))
+
+	// Export text messages as HTML if --save-html is enabled and --chat was used
+	if opts.SaveHTML && opts.Chat != "" {
+		for _, group := range dialogs {
+			for _, d := range group {
+				if len(d.TextMessages) > 0 {
+					chatName := opts.Chat
+					chatID := tmessage.GetDialogPeerID(d.Peer)
+
+					// Convert tmessage.TextMsg to dl.TextMessage
+					textMsgs := make([]TextMessage, len(d.TextMessages))
+					for i, tm := range d.TextMessages {
+						textMsgs[i] = TextMessage{
+							ID:           tm.ID,
+							Date:         tm.Date,
+							Text:         tm.Text,
+							Entities:     tm.Entities,
+							ReplyToMsgID: tm.ReplyToMsgID,
+							FromName:     tm.FromName,
+						}
+					}
+
+					if err := exportTextMessagesHTML(opts.Dir, chatName, chatID, textMsgs); err != nil {
+						logctx.From(ctx).Warn("Failed to export text messages as HTML",
+							zap.Error(err))
+					}
+				}
+			}
+		}
+	}
 
 	if opts.Serve {
 		return serve(ctx, kvd, pool, dialogs, opts.Port, opts.Takeout)

--- a/app/dl/htmlexport.go
+++ b/app/dl/htmlexport.go
@@ -1,0 +1,386 @@
+package dl
+
+import (
+	"fmt"
+	"html"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/gotd/td/tg"
+)
+
+// HTML tag constants to avoid goconst lint warnings.
+const (
+	htmlCloseB = "</b>"
+	htmlCloseA = "</a>"
+)
+
+// TextMessage holds the data for a single text-only message to be exported as HTML.
+type TextMessage struct {
+	ID       int
+	Date     int
+	Text     string
+	Entities []tg.MessageEntityClass
+	// ReplyToMsgID is the ID of the message this is replying to (0 if not a reply)
+	ReplyToMsgID int
+	// FromName is the sender name (if available)
+	FromName string
+}
+
+// exportTextMessagesHTML writes a self-contained HTML file with all collected text messages.
+// The file is saved to dir/chatName_text_messages.html
+func exportTextMessagesHTML(dir string, chatName string, chatID int64, messages []TextMessage) error {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	// Sort messages by ID (ascending = chronological)
+	sort.Slice(messages, func(i, j int) bool {
+		return messages[i].ID < messages[j].ID
+	})
+
+	// Sanitize chat name for filename
+	safeName := sanitizeFilename(chatName)
+	filename := fmt.Sprintf("%s_%d_text_messages.html", safeName, chatID)
+	path := filepath.Join(dir, filename)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create dir for HTML export: %w", err)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create HTML file: %w", err)
+	}
+	defer f.Close()
+
+	// Write HTML header
+	fmt.Fprintf(f, `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>%s — Text Messages</title>
+<style>
+:root {
+  --bg: #0e1621;
+  --msg-bg: #182533;
+  --msg-border: #1e3a5f;
+  --text: #e4e6ea;
+  --text-muted: #6c7883;
+  --accent: #3daee0;
+  --link: #6ab3f3;
+  --code-bg: #1c2e3f;
+  --date-bg: rgba(0,0,0,0.35);
+  --reply-border: #3daee0;
+  --reply-bg: rgba(61,174,224,0.08);
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 0;
+}
+.container {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 20px 16px 60px;
+}
+.header {
+  text-align: center;
+  padding: 24px 0 32px;
+  border-bottom: 1px solid var(--msg-border);
+  margin-bottom: 24px;
+}
+.header h1 {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--accent);
+}
+.header .meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+.date-separator {
+  text-align: center;
+  margin: 20px 0 12px;
+}
+.date-separator span {
+  background: var(--date-bg);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 14px;
+  border-radius: 12px;
+}
+.msg {
+  background: var(--msg-bg);
+  border: 1px solid var(--msg-border);
+  border-radius: 12px;
+  padding: 10px 14px;
+  margin-bottom: 6px;
+  max-width: 85%%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  position: relative;
+}
+.msg .sender {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+.msg .body {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.msg .body a {
+  color: var(--link);
+  text-decoration: none;
+}
+.msg .body a:hover {
+  text-decoration: underline;
+}
+.msg .body code {
+  background: var(--code-bg);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  font-size: 13px;
+}
+.msg .body pre {
+  background: var(--code-bg);
+  padding: 10px 12px;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 6px 0;
+  font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  font-size: 13px;
+}
+.msg .reply-ref {
+  background: var(--reply-bg);
+  border-left: 3px solid var(--reply-border);
+  padding: 4px 8px;
+  margin-bottom: 6px;
+  border-radius: 0 6px 6px 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.msg .time {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: right;
+  margin-top: 4px;
+}
+.msg .msg-id {
+  font-size: 10px;
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+.footer {
+  text-align: center;
+  padding: 24px 0;
+  border-top: 1px solid var(--msg-border);
+  margin-top: 24px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+</style>
+</head>
+<body>
+<div class="container">
+<div class="header">
+  <h1>%s</h1>
+  <div class="meta">%d text messages · Exported on %s</div>
+</div>
+`,
+		html.EscapeString(chatName),
+		html.EscapeString(chatName),
+		len(messages),
+		time.Now().Format("2006-01-02 15:04:05"),
+	)
+
+	// Group messages by date and render
+	var lastDate string
+	for _, msg := range messages {
+		msgTime := time.Unix(int64(msg.Date), 0)
+		dateStr := msgTime.Format("January 2, 2006")
+
+		if dateStr != lastDate {
+			fmt.Fprintf(f, "<div class=\"date-separator\"><span>%s</span></div>\n", html.EscapeString(dateStr))
+			lastDate = dateStr
+		}
+
+		// Render message
+		fmt.Fprintf(f, "<div class=\"msg\" id=\"msg-%d\">\n", msg.ID)
+
+		// Sender name if available
+		if msg.FromName != "" {
+			fmt.Fprintf(f, "  <div class=\"sender\">%s</div>\n", html.EscapeString(msg.FromName))
+		}
+
+		// Reply reference
+		if msg.ReplyToMsgID > 0 {
+			fmt.Fprintf(f, "  <div class=\"reply-ref\">↩ Reply to <a href=\"#msg-%d\">message #%d</a></div>\n",
+				msg.ReplyToMsgID, msg.ReplyToMsgID)
+		}
+
+		// Message body with entity formatting
+		formattedText := formatMessageEntities(msg.Text, msg.Entities)
+		fmt.Fprintf(f, "  <div class=\"body\">%s</div>\n", formattedText)
+
+		// Timestamp and message ID
+		fmt.Fprintf(f, "  <div class=\"time\">%s <span class=\"msg-id\">#%d</span></div>\n",
+			msgTime.Format("15:04"), msg.ID)
+
+		fmt.Fprintf(f, "</div>\n")
+	}
+
+	// Footer
+	fmt.Fprintf(f, `<div class="footer">
+  Exported by tdl · Chat ID: %d · %d messages
+</div>
+</div>
+</body>
+</html>
+`, chatID, len(messages))
+
+	color.Green("📄 Saved %d text messages to '%s'", len(messages), path)
+	return nil
+}
+
+// formatMessageEntities applies Telegram entity formatting (bold, italic, links, code, etc.)
+// to the message text, producing safe HTML output.
+func formatMessageEntities(text string, entities []tg.MessageEntityClass) string {
+	if len(entities) == 0 {
+		return html.EscapeString(text)
+	}
+
+	runes := []rune(text)
+
+	// Build a list of insert operations (open/close tags at rune positions)
+	type tag struct {
+		pos   int
+		close bool
+		order int // for stable sorting: opens before closes at same position
+		html  string
+	}
+
+	var tags []tag
+
+	for _, ent := range entities {
+		var offset, length int
+		var openTag, closeTag string
+
+		switch e := ent.(type) {
+		case *tg.MessageEntityBold:
+			offset, length = e.Offset, e.Length
+			openTag, closeTag = "<b>", htmlCloseB
+		case *tg.MessageEntityItalic:
+			offset, length = e.Offset, e.Length
+			openTag, closeTag = "<i>", "</i>"
+		case *tg.MessageEntityUnderline:
+			offset, length = e.Offset, e.Length
+			openTag, closeTag = "<u>", "</u>"
+		case *tg.MessageEntityStrike:
+			offset, length = e.Offset, e.Length
+			openTag, closeTag = "<s>", "</s>"
+		case *tg.MessageEntityCode:
+			offset, length = e.Offset, e.Length
+			openTag, closeTag = "<code>", "</code>"
+		case *tg.MessageEntityPre:
+			offset, length = e.Offset, e.Length
+			lang := ""
+			if e.Language != "" {
+				lang = fmt.Sprintf(" data-lang=\"%s\"", html.EscapeString(e.Language))
+			}
+			openTag = fmt.Sprintf("<pre%s>", lang)
+			closeTag = "</pre>"
+		case *tg.MessageEntityTextURL:
+			offset, length = e.Offset, e.Length
+			openTag = fmt.Sprintf("<a href=\"%s\" target=\"_blank\" rel=\"noopener\">", html.EscapeString(e.URL))
+			closeTag = htmlCloseA
+		case *tg.MessageEntityURL:
+			offset, length = e.Offset, e.Length
+			urlText := string(runes[offset : offset+length])
+			openTag = fmt.Sprintf("<a href=\"%s\" target=\"_blank\" rel=\"noopener\">", html.EscapeString(urlText))
+			closeTag = htmlCloseA
+		case *tg.MessageEntityMentionName:
+			offset, length = e.Offset, e.Length
+			openTag = fmt.Sprintf("<b title=\"User ID: %d\">", e.UserID)
+			closeTag = htmlCloseB
+		case *tg.MessageEntityMention:
+			offset, length = e.Offset, e.Length
+			mention := string(runes[offset : offset+length])
+			openTag = fmt.Sprintf("<a href=\"https://t.me/%s\" target=\"_blank\" rel=\"noopener\">",
+				html.EscapeString(strings.TrimPrefix(mention, "@")))
+			closeTag = htmlCloseA
+		case *tg.MessageEntityHashtag:
+			offset, length = e.Offset, e.Length
+			openTag = "<b>"
+			closeTag = htmlCloseB
+		case *tg.MessageEntitySpoiler:
+			offset, length = e.Offset, e.Length
+			openTag = "<span style=\"background:var(--text);color:var(--text);cursor:pointer\" onclick=\"this.style.color='inherit';this.style.background='transparent'\">"
+			closeTag = "</span>"
+		case *tg.MessageEntityBlockquote:
+			offset, length = e.Offset, e.Length
+			openTag = "<blockquote style=\"border-left:3px solid var(--accent);padding-left:8px;margin:4px 0;color:var(--text-muted)\">"
+			closeTag = "</blockquote>"
+		default:
+			continue
+		}
+
+		tags = append(tags, tag{pos: offset, close: false, order: 0, html: openTag})
+		tags = append(tags, tag{pos: offset + length, close: true, order: 1, html: closeTag})
+	}
+
+	// Sort tags: by position, then closes before opens at same position
+	sort.SliceStable(tags, func(i, j int) bool {
+		if tags[i].pos != tags[j].pos {
+			return tags[i].pos < tags[j].pos
+		}
+		return tags[i].order > tags[j].order // closes first
+	})
+
+	// Build output
+	var b strings.Builder
+	tagIdx := 0
+	for i, r := range runes {
+		// Insert any tags at this position
+		for tagIdx < len(tags) && tags[tagIdx].pos == i {
+			b.WriteString(tags[tagIdx].html)
+			tagIdx++
+		}
+		b.WriteString(html.EscapeString(string(r)))
+	}
+	// Flush remaining tags at end position
+	for tagIdx < len(tags) {
+		b.WriteString(tags[tagIdx].html)
+		tagIdx++
+	}
+
+	return b.String()
+}
+
+// sanitizeFilename removes or replaces characters that are not safe for filenames.
+func sanitizeFilename(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_", "*", "_",
+		"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_",
+		" ", "_",
+	)
+	result := replacer.Replace(name)
+	if len(result) > 60 {
+		result = result[:60]
+	}
+	return result
+}

--- a/cmd/dl.go
+++ b/cmd/dl.go
@@ -23,8 +23,8 @@ func NewDownload() *cobra.Command {
 		Short:   "Download anything from Telegram (protected) chat",
 		GroupID: groupTools.ID,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(opts.URLs) == 0 && len(opts.Files) == 0 {
-				return fmt.Errorf("no urls or files provided")
+			if len(opts.URLs) == 0 && len(opts.Files) == 0 && opts.Chat == "" {
+				return fmt.Errorf("no urls, files, or chat provided")
 			}
 
 			opts.Template = viper.GetString(consts.FlagDlTemplate)
@@ -60,6 +60,13 @@ func NewDownload() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Desc, "desc", false, "download files from the newest to the oldest ones (may affect resume download)")
 	cmd.Flags().BoolVar(&opts.Takeout, "takeout", false, "takeout sessions let you export data from your account with lower flood wait limits.")
 	cmd.Flags().BoolVar(&opts.Group, "group", false, "auto detect grouped message and download all of them")
+
+	// chat-based download flags
+	cmd.Flags().StringVarP(&opts.Chat, "chat", "c", "", "chat id or username to download all media from. Supports -100XXXXXXXXXX format")
+	cmd.Flags().IntVar(&opts.Topic, "topic", 0, "topic id for forum groups (downloads only messages within the topic)")
+	cmd.Flags().IntVar(&opts.MsgStart, "msg-start", 0, "optional: minimum message id to download (default: from the beginning)")
+	cmd.Flags().IntVar(&opts.MsgEnd, "msg-end", 0, "optional: maximum message id to download (default: to the latest)")
+	cmd.Flags().BoolVar(&opts.SaveHTML, "save-html", true, "save text messages (non-media) as an HTML file when using --chat (default: true)")
 
 	// resume flags, if both false then ask user
 	cmd.Flags().BoolVar(&opts.Continue, _continue, false, "continue the last download directly")

--- a/pkg/consts/flag.go
+++ b/pkg/consts/flag.go
@@ -13,4 +13,9 @@ const (
 	FlagNTP              = "ntp"
 	FlagReconnectTimeout = "reconnect-timeout"
 	FlagDlTemplate       = "template"
+	FlagChat             = "chat"
+	FlagTopic            = "topic"
+	FlagMsgStart         = "msg-start"
+	FlagMsgEnd           = "msg-end"
+	FlagSaveHTML         = "save-html"
 )

--- a/pkg/tmessage/chat.go
+++ b/pkg/tmessage/chat.go
@@ -1,0 +1,177 @@
+package tmessage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/go-faster/errors"
+	"github.com/gotd/td/telegram/peers"
+	"github.com/gotd/td/telegram/query"
+	"github.com/gotd/td/telegram/query/messages"
+	"github.com/gotd/td/tg"
+	"go.uber.org/zap"
+
+	"github.com/iyear/tdl/core/dcpool"
+	"github.com/iyear/tdl/core/logctx"
+	"github.com/iyear/tdl/core/storage"
+	"github.com/iyear/tdl/core/util/tutil"
+)
+
+// FromChat creates a ParseSource that collects all media message IDs from a chat
+// by iterating the chat history via the Telegram API. This avoids the need to
+// pass individual message links or export JSON files.
+//
+// chat: chat ID (numeric) or username
+// topic: topic root message ID (0 = no topic, iterate full history)
+// msgStart: minimum message ID to include (0 = no lower bound)
+// msgEnd: maximum message ID to include (0 = no upper bound)
+func FromChat(ctx context.Context, pool dcpool.Pool, kvd storage.Storage, chat string, topic int, msgStart int, msgEnd int) ParseSource {
+	return func() ([]*Dialog, error) {
+		manager := peers.Options{Storage: storage.NewPeers(kvd)}.
+			Build(pool.Default(ctx))
+
+		// Normalize chat ID: handle -100XXXXXXXXXX format
+		normalizedChat := normalizeChatID(chat)
+
+		peer, err := tutil.GetInputPeer(ctx, manager, normalizedChat)
+		if err != nil {
+			return nil, errors.Wrapf(err, "resolve chat '%s'", chat)
+		}
+
+		logctx.From(ctx).Info("Resolved chat for download",
+			zap.Int64("peer_id", peer.ID()),
+			zap.String("peer_name", peer.VisibleName()),
+			zap.Int("topic", topic),
+			zap.Int("msg_start", msgStart),
+			zap.Int("msg_end", msgEnd))
+
+		color.Cyan("Collecting messages from '%s' (ID: %d)...", peer.VisibleName(), peer.ID())
+
+		// Build the appropriate query (topic or full history)
+		var q messages.Query
+		if topic > 0 {
+			q = query.NewQuery(pool.Default(ctx)).Messages().GetReplies(peer.InputPeer()).MsgID(topic)
+		} else {
+			q = query.NewQuery(pool.Default(ctx)).Messages().GetHistory(peer.InputPeer())
+		}
+
+		iter := messages.NewIterator(q, 100)
+
+		// If msgEnd is set, start iterating from that point
+		if msgEnd > 0 {
+			iter = iter.OffsetID(msgEnd + 1)
+		}
+
+		msgIDs := make([]int, 0)
+		textMsgs := make([]TextMsg, 0)
+		for iter.Next(ctx) {
+			msg := iter.Value()
+
+			m, ok := msg.Msg.(*tg.Message)
+			if !ok {
+				continue
+			}
+
+			// Stop if we've gone past the start boundary
+			if msgStart > 0 && m.ID < msgStart {
+				break
+			}
+
+			// Collect media messages for download
+			if hasMedia(m) {
+				msgIDs = append(msgIDs, m.ID)
+			}
+
+			// Collect text messages for HTML export (including captions on media messages)
+			if m.Message != "" {
+				tm := TextMsg{
+					ID:       m.ID,
+					Date:     m.Date,
+					Text:     m.Message,
+					Entities: m.Entities,
+				}
+
+				// Extract reply info
+				if replyTo, ok := m.GetReplyTo(); ok {
+					if rh, ok := replyTo.(*tg.MessageReplyHeader); ok {
+						tm.ReplyToMsgID = rh.ReplyToMsgID
+					}
+				}
+
+				// Try to extract sender name from the message's FromID
+				if fromID, ok := m.GetFromID(); ok {
+					tm.FromName = extractSenderName(ctx, manager, fromID)
+				}
+
+				textMsgs = append(textMsgs, tm)
+			}
+		}
+
+		if err := iter.Err(); err != nil {
+			return nil, errors.Wrap(err, "iterate chat messages")
+		}
+
+		if len(msgIDs) == 0 && len(textMsgs) == 0 {
+			return nil, fmt.Errorf("no messages found in chat '%s' (ID: %d)", peer.VisibleName(), peer.ID())
+		}
+
+		if len(msgIDs) > 0 {
+			color.Green("Found %d media messages to download", len(msgIDs))
+		}
+		if len(textMsgs) > 0 {
+			color.Green("Found %d text messages for HTML export", len(textMsgs))
+		}
+
+		return []*Dialog{{
+			Peer:         peer.InputPeer(),
+			Messages:     msgIDs,
+			TextMessages: textMsgs,
+		}}, nil
+	}
+}
+
+// extractSenderName tries to resolve a PeerClass into a display name.
+func extractSenderName(ctx context.Context, manager *peers.Manager, fromID tg.PeerClass) string {
+	switch f := fromID.(type) {
+	case *tg.PeerUser:
+		if p, err := manager.ResolveUserID(ctx, f.UserID); err == nil {
+			return p.VisibleName()
+		}
+	case *tg.PeerChannel:
+		if p, err := manager.ResolveChannelID(ctx, f.ChannelID); err == nil {
+			return p.VisibleName()
+		}
+	case *tg.PeerChat:
+		if p, err := manager.ResolveChatID(ctx, f.ChatID); err == nil {
+			return p.VisibleName()
+		}
+	}
+	return ""
+}
+
+// hasMedia checks if a message contains downloadable media (document or photo).
+func hasMedia(m *tg.Message) bool {
+	md, ok := m.GetMedia()
+	if !ok {
+		return false
+	}
+
+	switch md.(type) {
+	case *tg.MessageMediaDocument, *tg.MessageMediaPhoto:
+		return true
+	default:
+		return false
+	}
+}
+
+// normalizeChatID handles the common Telegram marked channel ID format.
+// Users often encounter IDs like -1001931890116 (from bot APIs), but the
+// internal Telegram channel ID is 1931890116. This strips the -100 prefix.
+func normalizeChatID(chat string) string {
+	if strings.HasPrefix(chat, "-100") && len(chat) > 4 {
+		return chat[4:]
+	}
+	return chat
+}

--- a/pkg/tmessage/tmessage.go
+++ b/pkg/tmessage/tmessage.go
@@ -4,13 +4,38 @@ import (
 	"github.com/gotd/td/tg"
 )
 
+// TextMsg holds the essential data of a text-only message (no downloadable media)
+// for later export as HTML.
+type TextMsg struct {
+	ID           int
+	Date         int
+	Text         string
+	Entities     []tg.MessageEntityClass
+	ReplyToMsgID int
+	FromName     string
+}
+
 type Dialog struct {
-	Peer     tg.InputPeerClass
-	Messages []int
+	Peer         tg.InputPeerClass
+	Messages     []int
+	TextMessages []TextMsg // text-only messages (for HTML export)
 }
 
 type ParseSource func() ([]*Dialog, error)
 
 func Parse(src ParseSource) ([]*Dialog, error) {
 	return src()
+}
+
+// GetDialogPeerID extracts the numeric ID from an InputPeerClass.
+func GetDialogPeerID(peer tg.InputPeerClass) int64 {
+	switch p := peer.(type) {
+	case *tg.InputPeerUser:
+		return p.UserID
+	case *tg.InputPeerChat:
+		return p.ChatID
+	case *tg.InputPeerChannel:
+		return p.ChannelID
+	}
+	return 0
 }


### PR DESCRIPTION
### Summary

This PR adds support for downloading all media and messages from a Telegram channel, group, or topic directly using the `--chat` flag, without requiring a prior message export step.


### What gets downloaded

- **Media files** — all attachments (photos, videos, documents, etc.)
- **Text messages** — saved as an `.html` file for easy reading

### New flags

| Flag | Description |
|---|---|
| `--chat <id>` | Target channel or group ID |
| `--topic <id>` | Target a specific topic within a group |
| `--msg-start <id>` | Start of message range (optional) |
| `--msg-end <id>` | End of message range (optional) |

### Usage & Examples

**Download everything from a channel or group:**
```bash
tdl dl --chat <chat_id>

# Example
tdl dl --chat 8493874389
```

**Download everything from a specific topic:**
```bash
tdl dl --chat <chat_id> --topic <topic_id>

# Example
tdl dl --chat 8493874389 --topic 9383
```

**Optional: limit by message range:**
```bash
tdl dl --chat <chat_id> --msg-start <start_id> --msg-end <end_id>

# Example (messages 100 to 500)
tdl dl --chat 8493874389 --msg-start 100 --msg-end 500
```
