### PR TITLE
Support FileCaption fallback for grouped media downloads

### DIFF
--- a/app/dl/iter.go
+++ b/app/dl/iter.go
@@ -206,6 +206,10 @@ func (i *iter) process(ctx context.Context) (ret bool, skip bool) {
 }
 
 func (i *iter) processSingle(ctx context.Context, message *tg.Message, from peers.Peer, logicalPos int) (bool, bool) {
+	return i.processSingleWithCaption(ctx, message, from, logicalPos, message.Message)
+}
+
+func (i *iter) processSingleWithCaption(ctx context.Context, message *tg.Message, from peers.Peer, logicalPos int, fileCaption string) (bool, bool) {
 	item, ok := tmedia.GetMedia(message)
 	if !ok {
 		logctx.From(ctx).Warn("Message has no media",
@@ -231,7 +235,7 @@ func (i *iter) processSingle(ctx context.Context, message *tg.Message, from peer
 		MessageID:    message.ID,
 		MessageDate:  int64(message.Date),
 		FileName:     item.Name,
-		FileCaption:  message.Message,
+		FileCaption:  fileCaption,
 		FileSize:     utils.Byte.FormatBinaryBytes(item.Size),
 		DownloadDate: time.Now().Unix(),
 	})
@@ -288,6 +292,7 @@ func (i *iter) processGrouped(ctx context.Context, message *tg.Message, from pee
 	}
 
 	hasValid := false
+	groupCaption := groupedCaption(grouped)
 
 	for idx, msg := range grouped {
 		logicalPos := startLogicalPos + idx
@@ -297,7 +302,7 @@ func (i *iter) processGrouped(ctx context.Context, message *tg.Message, from pee
 			continue
 		}
 
-		ret, skip := i.processSingle(ctx, msg, from, logicalPos)
+		ret, skip := i.processSingleWithCaption(ctx, msg, from, logicalPos, fileCaption(msg, groupCaption))
 
 		// if processSingle encounters a fatal error (not just skip), propagate it
 		if !ret && !skip {
@@ -314,6 +319,26 @@ func (i *iter) processGrouped(ctx context.Context, message *tg.Message, from pee
 	i.logicalPos += len(grouped)
 
 	return hasValid, !hasValid
+}
+
+func groupedCaption(grouped []*tg.Message) string {
+	for _, msg := range grouped {
+		if msg == nil || msg.Message == "" {
+			continue
+		}
+
+		return msg.Message
+	}
+
+	return ""
+}
+
+func fileCaption(message *tg.Message, fallback string) string {
+	if message.Message != "" {
+		return message.Message
+	}
+
+	return fallback
 }
 
 func (i *iter) Value() downloader.Elem {

--- a/app/dl/iter_test.go
+++ b/app/dl/iter_test.go
@@ -6,9 +6,46 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gotd/td/tg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGroupedCaption(t *testing.T) {
+	t.Run("uses first non-empty grouped message caption", func(t *testing.T) {
+		caption := groupedCaption([]*tg.Message{
+			{ID: 1, Message: ""},
+			{ID: 2, Message: "album caption"},
+			{ID: 3, Message: "later caption"},
+		})
+
+		require.Equal(t, "album caption", caption)
+	})
+
+	t.Run("returns empty caption when group has no caption", func(t *testing.T) {
+		caption := groupedCaption([]*tg.Message{
+			nil,
+			{ID: 1, Message: ""},
+			{ID: 2, Message: ""},
+		})
+
+		require.Empty(t, caption)
+	})
+}
+
+func TestFileCaption(t *testing.T) {
+	t.Run("keeps message caption when present", func(t *testing.T) {
+		caption := fileCaption(&tg.Message{Message: "file caption"}, "album caption")
+
+		require.Equal(t, "file caption", caption)
+	})
+
+	t.Run("falls back to grouped caption", func(t *testing.T) {
+		caption := fileCaption(&tg.Message{Message: ""}, "album caption")
+
+		require.Equal(t, "album caption", caption)
+	})
+}
 
 // TestIterDeletedMessageHandling verifies that deleted messages are handled correctly
 // without causing the program to crash. This test simulates the scenario where GetSingleMessage

--- a/docs/content/en/guide/template.md
+++ b/docs/content/en/guide/template.md
@@ -20,7 +20,7 @@ Template syntax is based on [Go's text/template](https://golang.org/pkg/text/tem
 |  `MessageID`   |           Telegram message id            |
 | `MessageDate`  |     Telegram message date(timestamp)     |
 |   `FileName`   |            Telegram file name            |
-| `FileCaption`  | Telegram file caption, aka. text message |
+| `FileCaption`  | Telegram file caption, aka. text message. In grouped media, files without their own caption use the first non-empty group caption. |
 |   `FileSize`   |   Human-readable file size, like `1GB`   |
 | `DownloadDate` |         Download date(timestamp)         |
 

--- a/docs/content/zh/guide/template.md
+++ b/docs/content/zh/guide/template.md
@@ -20,7 +20,7 @@ bookToC: false
 |  `MessageID`   |     Telegram 消息ID     |
 | `MessageDate`  |  Telegram 消息日期（时间戳）   |
 |   `FileName`   |     Telegram 文件名      |
-| `FileCaption`  | Telegram 文件说明，也就是文本消息 |
+| `FileCaption`  | Telegram 文件说明，也就是文本消息。组合消息中没有自身 caption 的文件会使用同组第一个非空 caption。 |
 |   `FileSize`   |   可读的文件大小，例如 `1GB`    |
 | `DownloadDate` |       下载日期（时间戳）       |
 


### PR DESCRIPTION
## Summary
- Apply the first non-empty caption in a grouped message as a fallback for group members that do not have their own caption.
- Keep existing single-message behavior and preserve per-file captions when present.
- Document the FileCaption behavior for grouped media templates.

## Tests
- go test ./app/dl
- go test ./app/dl ./app/chat ./pkg/tmessage
- go test $(go list ./... | grep -v '^github.com/iyear/tdl/test$')
- go test ./... (from core/)
- go test ./... (from extension/)

Closes #1208