### PR TITLE
feat(dl): support downloading unlocked paid media from chat history

### DIFF
--- a/app/dl/dl.go
+++ b/app/dl/dl.go
@@ -33,6 +33,7 @@ type Options struct {
 	Template   string
 	URLs       []string
 	Files      []string
+	PaidChats  []string
 	Include    []string
 	Exclude    []string
 	Desc       bool
@@ -61,6 +62,7 @@ func Run(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts Opti
 	parsers := []parser{
 		{Data: opts.URLs, Parser: tmessage.FromURL(ctx, pool, kvd, opts.URLs)},
 		{Data: opts.Files, Parser: tmessage.FromFile(ctx, pool, kvd, opts.Files, true)},
+		{Data: opts.PaidChats, Parser: tmessage.FromPaidHistory(ctx, pool, kvd, opts.PaidChats)},
 	}
 	dialogs, err := collectDialogs(parsers)
 	if err != nil {

--- a/app/dl/iter.go
+++ b/app/dl/iter.go
@@ -410,8 +410,10 @@ func (i *iter) Total() int {
 	defer i.mu.Unlock()
 
 	total := 0
-	for _, m := range i.dialogs {
-		total += len(m.Messages)
+	for _, dialog := range i.dialogs {
+		for _, messageID := range dialog.Messages {
+			total += dialog.MediaCount(messageID)
+		}
 	}
 	return total
 }

--- a/app/dl/iter.go
+++ b/app/dl/iter.go
@@ -114,7 +114,7 @@ func newIter(pool dcpool.Pool, manager *peers.Manager, dialog [][]*tmessage.Dial
 		counter:        atomic.NewInt64(-1),
 		skippedDeleted: atomic.NewInt64(0),
 		deletedIDs:     make([]string, 0),
-		elem:           make(chan downloader.Elem, 10), // grouped message buffer
+		elem:           make(chan downloader.Elem, 10), // grouped/paid media buffer
 		err:            nil,
 	}, nil
 }
@@ -194,6 +194,12 @@ func (i *iter) process(ctx context.Context) (ret bool, skip bool) {
 		return i.processGrouped(ctx, message, from, startLogicalPos)
 	}
 
+	if media, ok := message.GetMedia(); ok {
+		if paid, ok := media.(*tg.MessageMediaPaidMedia); ok {
+			return i.processPaid(ctx, message, from, startLogicalPos, paid)
+		}
+	}
+
 	// check if finished
 	if _, ok := i.finished[startLogicalPos]; ok {
 		i.logicalPos++ // increment logical position even if skipped
@@ -216,12 +222,16 @@ func (i *iter) processSingle(ctx context.Context, message *tg.Message, from peer
 		return false, true
 	}
 
+	return i.processMedia(message, from, logicalPos, item)
+}
+
+func (i *iter) processMedia(message *tg.Message, from peers.Peer, logicalPos int, item *tmedia.Media) (bool, bool) {
 	// process include and exclude
 	ext := filepath.Ext(item.Name)
-	if _, ok = i.include[ext]; len(i.include) > 0 && !ok {
+	if _, ok := i.include[ext]; len(i.include) > 0 && !ok {
 		return false, true
 	}
-	if _, ok = i.exclude[ext]; len(i.exclude) > 0 && ok {
+	if _, ok := i.exclude[ext]; len(i.exclude) > 0 && ok {
 		return false, true
 	}
 
@@ -278,6 +288,52 @@ func (i *iter) processSingle(ctx context.Context, message *tg.Message, from peer
 	}
 
 	return true, false
+}
+
+func (i *iter) processPaid(ctx context.Context, message *tg.Message, from peers.Peer, startLogicalPos int,
+	paid *tg.MessageMediaPaidMedia,
+) (bool, bool) {
+	media := tmedia.GetPaidMedia(paid)
+	if len(media) == 0 {
+		logctx.From(ctx).Warn("Paid media has no items",
+			zap.Int64("dialog_id", from.ID()),
+			zap.Int("message_id", message.ID),
+		)
+		i.logicalPos++
+		return false, true
+	}
+
+	hasValid := false
+	unavailable := 0
+	for idx, item := range media {
+		logicalPos := startLogicalPos + idx
+		if _, ok := i.finished[logicalPos]; ok {
+			continue
+		}
+		if item == nil {
+			unavailable++
+			continue
+		}
+
+		ret, skip := i.processMedia(message, from, logicalPos, item)
+		if !ret && !skip {
+			return false, false
+		}
+		if ret {
+			hasValid = true
+		}
+	}
+
+	i.logicalPos += len(media)
+	if unavailable > 0 {
+		logctx.From(ctx).Warn("Paid media contains unavailable previews",
+			zap.Int64("dialog_id", from.ID()),
+			zap.Int("message_id", message.ID),
+			zap.Int("unavailable", unavailable),
+		)
+	}
+
+	return hasValid, !hasValid
 }
 
 func (i *iter) processGrouped(ctx context.Context, message *tg.Message, from peers.Peer, startLogicalPos int) (bool, bool) {

--- a/app/dl/iter_test.go
+++ b/app/dl/iter_test.go
@@ -3,12 +3,29 @@ package dl
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iyear/tdl/pkg/tmessage"
 )
+
+func TestIterTotalCountsExpandedMedia(t *testing.T) {
+	it := &iter{
+		mu: &sync.Mutex{},
+		dialogs: []*tmessage.Dialog{
+			{
+				Messages:    []int{10, 11},
+				MediaCounts: map[int]int{10: 4},
+			},
+		},
+	}
+
+	require.Equal(t, 5, it.Total())
+}
 
 // TestIterDeletedMessageHandling verifies that deleted messages are handled correctly
 // without causing the program to crash. This test simulates the scenario where GetSingleMessage

--- a/cmd/dl.go
+++ b/cmd/dl.go
@@ -23,8 +23,8 @@ func NewDownload() *cobra.Command {
 		Short:   "Download anything from Telegram (protected) chat",
 		GroupID: groupTools.ID,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(opts.URLs) == 0 && len(opts.Files) == 0 {
-				return fmt.Errorf("no urls or files provided")
+			if len(opts.URLs) == 0 && len(opts.Files) == 0 && len(opts.PaidChats) == 0 {
+				return fmt.Errorf("no urls, files, or paid chats provided")
 			}
 
 			opts.Template = viper.GetString(consts.FlagDlTemplate)
@@ -46,6 +46,7 @@ func NewDownload() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&opts.URLs, "url", "u", []string{}, "telegram message links")
 	cmd.Flags().StringSliceVarP(&opts.Files, file, "f", []string{}, "official client exported files")
+	cmd.Flags().StringSliceVar(&opts.PaidChats, "paid-chat", []string{}, "scan complete chat history and download all paid media unlocked by the current account")
 
 	cmd.Flags().String(consts.FlagDlTemplate, `{{ .DialogID }}_{{ .MessageID }}_{{ filenamify .FileName }}`, "download file name template")
 
@@ -76,6 +77,7 @@ func NewDownload() *cobra.Command {
 	_ = cmd.MarkFlagDirname(dir)
 	cmd.MarkFlagsMutuallyExclusive(include, exclude)
 	cmd.MarkFlagsMutuallyExclusive(_continue, restart)
+	cmd.MarkFlagsMutuallyExclusive("paid-chat", "serve")
 
 	return cmd
 }

--- a/core/tmedia/media.go
+++ b/core/tmedia/media.go
@@ -46,6 +46,25 @@ func GetExtendedMedia(mm tg.MessageExtendedMediaClass) (*Media, bool) {
 	return ExtractMedia(m.Media)
 }
 
+// GetPaidMedia extracts downloadable media from a paid media message while
+// preserving the original extended_media positions. A nil entry represents a
+// preview that has not been unlocked for the current account.
+func GetPaidMedia(paid *tg.MessageMediaPaidMedia) []*Media {
+	if paid == nil {
+		return nil
+	}
+
+	media := make([]*Media, len(paid.ExtendedMedia))
+	for idx, extended := range paid.ExtendedMedia {
+		item, ok := GetExtendedMedia(extended)
+		if ok {
+			media[idx] = item
+		}
+	}
+
+	return media
+}
+
 func GetDocumentThumb(doc *tg.Document) (*Media, bool) {
 	thumbs, exists := doc.GetThumbs()
 	if !exists {

--- a/core/tmedia/media_test.go
+++ b/core/tmedia/media_test.go
@@ -1,0 +1,49 @@
+package tmedia
+
+import (
+	"testing"
+
+	"github.com/gotd/td/tg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPaidMedia(t *testing.T) {
+	paid := &tg.MessageMediaPaidMedia{
+		StarsAmount: 10,
+		ExtendedMedia: []tg.MessageExtendedMediaClass{
+			paidPhoto(101),
+			&tg.MessageExtendedMediaPreview{W: 320, H: 240},
+			paidPhoto(202),
+		},
+	}
+
+	media := GetPaidMedia(paid)
+	require.Len(t, media, 3)
+	require.NotNil(t, media[0])
+	assert.Equal(t, "101.jpg", media[0].Name)
+	assert.Nil(t, media[1], "locked previews must preserve their position")
+	require.NotNil(t, media[2])
+	assert.Equal(t, "202.jpg", media[2].Name)
+}
+
+func TestGetPaidMediaNil(t *testing.T) {
+	assert.Nil(t, GetPaidMedia(nil))
+}
+
+func paidPhoto(id int64) *tg.MessageExtendedMedia {
+	return &tg.MessageExtendedMedia{
+		Media: &tg.MessageMediaPhoto{
+			Photo: &tg.Photo{
+				ID:            id,
+				AccessHash:    id + 1,
+				FileReference: []byte{1, 2, 3},
+				Date:          1,
+				Sizes: []tg.PhotoSizeClass{
+					&tg.PhotoSize{Type: "x", W: 800, H: 600, Size: 1024},
+				},
+				DCID: 2,
+			},
+		},
+	}
+}

--- a/pkg/tmessage/paid_history.go
+++ b/pkg/tmessage/paid_history.go
@@ -1,0 +1,99 @@
+package tmessage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-faster/errors"
+	"github.com/gotd/td/telegram/peers"
+	"github.com/gotd/td/telegram/query"
+	"github.com/gotd/td/telegram/query/messages"
+	"github.com/gotd/td/tg"
+
+	"github.com/iyear/tdl/core/dcpool"
+	"github.com/iyear/tdl/core/storage"
+	"github.com/iyear/tdl/core/tmedia"
+	"github.com/iyear/tdl/core/util/tutil"
+)
+
+// FromPaidHistory scans complete chat histories and selects paid media that is
+// unlocked for the current account. Locked previews are not added to the
+// download queue.
+func FromPaidHistory(ctx context.Context, pool dcpool.Pool, kvd storage.Storage, chats []string) ParseSource {
+	return func() ([]*Dialog, error) {
+		if len(chats) == 0 {
+			return nil, nil
+		}
+
+		client := pool.Default(ctx)
+		manager := peers.Options{Storage: storage.NewPeers(kvd)}.Build(client)
+		dialogs := make([]*Dialog, 0, len(chats))
+		seen := make(map[string]struct{}, len(chats))
+
+		for _, chat := range chats {
+			peer, err := tutil.GetInputPeer(ctx, manager, chat)
+			if err != nil {
+				return nil, errors.Wrapf(err, "resolve paid media chat %q", chat)
+			}
+			peerKey := fmt.Sprintf("%T:%d", peer.InputPeer(), peer.ID())
+			if _, ok := seen[peerKey]; ok {
+				continue
+			}
+			seen[peerKey] = struct{}{}
+
+			dialog := &Dialog{
+				Peer:        peer.InputPeer(),
+				Messages:    make([]int, 0),
+				MediaCounts: make(map[int]int),
+			}
+			iter := messages.NewIterator(
+				query.NewQuery(client).Messages().GetHistory(peer.InputPeer()),
+				100,
+			)
+			for iter.Next(ctx) {
+				message, ok := iter.Value().Msg.(*tg.Message)
+				if !ok {
+					continue
+				}
+
+				count := unlockedPaidMediaCount(message)
+				if count == 0 {
+					continue
+				}
+				dialog.Messages = append(dialog.Messages, message.ID)
+				dialog.MediaCounts[message.ID] = count
+			}
+			if err := iter.Err(); err != nil {
+				return nil, errors.Wrapf(err, "scan paid media chat %q", chat)
+			}
+
+			if len(dialog.Messages) > 0 {
+				dialogs = append(dialogs, dialog)
+			}
+		}
+
+		if len(dialogs) == 0 {
+			return nil, errors.New("no unlocked paid media found")
+		}
+		return dialogs, nil
+	}
+}
+
+func unlockedPaidMediaCount(message *tg.Message) int {
+	media, ok := message.GetMedia()
+	if !ok {
+		return 0
+	}
+	paid, ok := media.(*tg.MessageMediaPaidMedia)
+	if !ok {
+		return 0
+	}
+
+	count := 0
+	for _, item := range tmedia.GetPaidMedia(paid) {
+		if item != nil {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/tmessage/paid_history_test.go
+++ b/pkg/tmessage/paid_history_test.go
@@ -1,0 +1,57 @@
+package tmessage
+
+import (
+	"testing"
+
+	"github.com/gotd/td/tg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnlockedPaidMediaCount(t *testing.T) {
+	withMedia := func(media tg.MessageMediaClass) *tg.Message {
+		message := &tg.Message{Media: media}
+		message.SetFlags()
+		return message
+	}
+	photo := func(id int64) *tg.MessageExtendedMedia {
+		return &tg.MessageExtendedMedia{Media: &tg.MessageMediaPhoto{Photo: &tg.Photo{
+			ID: id,
+			Sizes: []tg.PhotoSizeClass{&tg.PhotoSize{
+				Type: "x",
+				Size: 1,
+			}},
+		}}}
+	}
+
+	tests := []struct {
+		name    string
+		message *tg.Message
+		want    int
+	}{
+		{name: "no media", message: &tg.Message{}, want: 0},
+		{name: "ordinary media", message: withMedia(&tg.MessageMediaPhoto{}), want: 0},
+		{
+			name: "unlocked and preview items",
+			message: withMedia(&tg.MessageMediaPaidMedia{
+				ExtendedMedia: []tg.MessageExtendedMediaClass{
+					photo(1),
+					&tg.MessageExtendedMediaPreview{},
+					photo(2),
+				},
+			}),
+			want: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, unlockedPaidMediaCount(test.message))
+		})
+	}
+}
+
+func TestDialogMediaCount(t *testing.T) {
+	dialog := &Dialog{MediaCounts: map[int]int{10: 4}}
+	require.Equal(t, 4, dialog.MediaCount(10))
+	require.Equal(t, 1, dialog.MediaCount(11))
+}

--- a/pkg/tmessage/tmessage.go
+++ b/pkg/tmessage/tmessage.go
@@ -5,8 +5,18 @@ import (
 )
 
 type Dialog struct {
-	Peer     tg.InputPeerClass
-	Messages []int
+	Peer        tg.InputPeerClass
+	Messages    []int
+	MediaCounts map[int]int
+}
+
+// MediaCount returns the number of downloadable items represented by a
+// message. Most messages contain one item, while paid media can contain many.
+func (d *Dialog) MediaCount(messageID int) int {
+	if count, ok := d.MediaCounts[messageID]; ok {
+		return count
+	}
+	return 1
 }
 
 type ParseSource func() ([]*Dialog, error)


### PR DESCRIPTION
## Summary

Adds support for downloading Telegram paid media that has already been unlocked by the current user account.

It supports both individual paid-media message links and scanning an entire chat history for unlocked paid content.

## Changes

- recognize `MessageMediaPaidMedia` messages
- expand every downloadable item in `extended_media`
- preserve extended-media positions for resume tracking
- skip locked previews instead of treating them as downloadable files
- support both paid photos and paid documents/videos
- add `--paid-chat` to scan a complete chat history
- download only paid media unlocked by the current account
- avoid duplicate chat scans when the same chat is specified more than once
- count expanded paid-media items correctly in download progress
- make `--paid-chat` and `--serve` mutually exclusive because the current HTTP endpoint represents one media item per message
- add unit tests for paid-media extraction, filtering, and progress totals