### PR TITLE
feat(up): add --video, --album, --detect-video with parallel album pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ downloads
 tdl
 .hugo_build.lock
 .DS_Store
+.cache/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ English | <a href="README_zh.md">简体中文</a>
 - Faster than official clients
 - Download files from (protected) chats
 - Forward messages with automatic fallback and message routing
-- Upload files to Telegram
+- Upload files to Telegram, including streamable video and grouped albums
 - Export messages/members/subscribers to JSON
 
 ## Preview
@@ -29,6 +29,19 @@ English | <a href="README_zh.md">简体中文</a>
 It reaches my proxy's speed limit, and the **speed depends on whether you are a premium**
 
 ![](docs/assets/img/preview.gif)
+
+## Uploading media and albums
+
+The `upload` command has two extended pipelines beyond plain document upload:
+
+- `--video`: send `video/*` files as streamable inline video, extracting duration, resolution, and a thumbnail via `ffprobe`/`ffmpeg`. Combine with `--detect-video` to force `mp4`/`m4v`/`mov` files through this path regardless of MIME sniffing.
+- `--album`: group items whose base name matches `<model>_<YYYY-MM-DD>_<HH-MM-SS>` and send them as Telegram grouped media (up to 10 items per album). Non-matching files remain individual uploads. Files inside an album upload in parallel; each item is committed via `messages.uploadMedia` before `messages.sendMultiMedia` posts the group.
+
+Requirements and behavior:
+
+- `ffprobe` and `ffmpeg` on `PATH` when `--video` or `--detect-video` is active.
+- Probed metadata and generated thumbnails are cached under `.cache/metadata/` and `.cache/thumbs/`, keyed by the source file's SHA-256. A sidecar thumbnail (`<video>.jpg`, `.jpeg`, or `.png` next to the video) is picked up automatically; otherwise a 320×320 JPEG ≤ 200 KB is generated.
+- Captions follow the existing `--caption` expression. Inside an album only the first item carries the caption, matching Telegram grouped-media semantics.
 
 ## Documentation
 

--- a/app/up/elem.go
+++ b/app/up/elem.go
@@ -1,63 +1,48 @@
 package up
 
 import (
-	"os"
-	"path/filepath"
+	"fmt"
 
-	"github.com/gotd/td/telegram/message/entity"
-	"github.com/gotd/td/telegram/peers"
 	"github.com/gotd/td/tg"
 
 	"github.com/iyear/tdl/core/uploader"
 )
 
 type iterElem struct {
-	file    *uploaderFile
-	thumb   *uploaderFile
-	to      peers.Peer
-	caption *entity.Builder
-	thread  int
-
-	asPhoto bool
-	remove  bool
+	task *uploadTask
 }
 
-func (e *iterElem) File() uploader.File {
-	return e.file
-}
-
-func (e *iterElem) Thumb() (uploader.File, bool) {
-	if e.thumb == nil {
-		return nil, false
-	}
-	return e.thumb, true
-}
-
-func (e *iterElem) Caption() (string, []tg.MessageEntityClass) {
-	return e.caption.Complete()
+func (e *iterElem) Media() []uploader.MediaDescriptor {
+	return e.task.media
 }
 
 func (e *iterElem) To() tg.InputPeerClass {
-	return e.to.InputPeer()
+	return e.task.to.InputPeer()
 }
 
 func (e *iterElem) Thread() int {
-	return e.thread
+	return e.task.thread
 }
 
-func (e *iterElem) AsPhoto() bool {
-	return e.asPhoto
+func (e *iterElem) Remove() bool {
+	return e.task.remove
 }
 
-type uploaderFile struct {
-	*os.File
-	size int64
+func (e *iterElem) Paths() []string {
+	return e.task.paths
 }
 
-func (u *uploaderFile) Name() string {
-	return filepath.Base(u.File.Name())
+func (e *iterElem) TotalSize() int64 {
+	return e.task.totalSize
 }
 
-func (u *uploaderFile) Size() int64 {
-	return u.size
+func (e *iterElem) Label() string {
+	if e.task.label != "" {
+		return e.task.label
+	}
+	return fmt.Sprintf("%d media -> %s(%d)", len(e.task.media), e.task.to.VisibleName(), e.task.to.ID())
+}
+
+func (e *iterElem) CaptionEntities(media uploader.MediaDescriptor) []tg.MessageEntityClass {
+	return e.task.captionEntities(media)
 }

--- a/app/up/iter.go
+++ b/app/up/iter.go
@@ -2,27 +2,40 @@ package up
 
 import (
 	"context"
-	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/expr-lang/expr/vm"
-	"github.com/gabriel-vasile/mimetype"
 	"github.com/go-faster/errors"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/gotd/td/telegram/message/entity"
 	"github.com/gotd/td/telegram/message/html"
 	"github.com/gotd/td/telegram/peers"
+	"github.com/gotd/td/tg"
 
 	"github.com/iyear/tdl/core/uploader"
-	"github.com/iyear/tdl/core/util/mediautil"
 	"github.com/iyear/tdl/core/util/tutil"
 	"github.com/iyear/tdl/pkg/texpr"
 )
 
-type File struct {
-	File  string
-	Thumb string
+type uploadTask struct {
+	media      []uploader.MediaDescriptor
+	to         peers.Peer
+	thread     int
+	remove     bool
+	paths      []string
+	totalSize  int64
+	label      string
+	entityByID map[string][]tg.MessageEntityClass
+}
+
+func (t *uploadTask) captionEntities(media uploader.MediaDescriptor) []tg.MessageEntityClass {
+	if t.entityByID == nil {
+		return nil
+	}
+	return t.entityByID[media.Path]
 }
 
 type dest struct {
@@ -30,134 +43,40 @@ type dest struct {
 	Thread int
 }
 
-type iter struct {
-	files   []*File
+type taskResolver struct {
 	to      *vm.Program
 	caption *vm.Program
 	chat    string
 	topic   int
-	photo   bool
-	remove  bool
-	delay   time.Duration
 	manager *peers.Manager
-
-	cur  int
-	err  error
-	file uploader.Elem
 }
 
-func newIter(files []*File, to, caption *vm.Program, chat string, topic int, photo, remove bool, delay time.Duration, manager *peers.Manager) *iter {
-	return &iter{
-		files:   files,
-		to:      to,
-		caption: caption,
-		chat:    chat,
-		topic:   topic,
-		photo:   photo,
-		remove:  remove,
-		delay:   delay,
-		manager: manager,
+func (r *taskResolver) resolve(ctx context.Context, file *File) (peers.Peer, int, string, []tg.MessageEntityClass, error) {
+	env := exprEnv(ctx, file)
 
-		cur:  0,
-		err:  nil,
-		file: nil,
+	to, thread, err := r.resolveDest(ctx, env)
+	if err != nil {
+		return nil, 0, "", nil, errors.Wrap(err, "resolve destination")
 	}
+
+	caption, entities, err := r.resolveCaption(env)
+	if err != nil {
+		return nil, 0, "", nil, errors.Wrap(err, "resolve caption")
+	}
+
+	return to, thread, caption, entities, nil
 }
 
-func (i *iter) Next(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		i.err = ctx.Err()
-		return false
-	default:
-	}
-
-	if i.cur >= len(i.files) || i.err != nil {
-		return false
-	}
-
-	// if delay is set, sleep for a while for each iteration
-	if i.delay > 0 && i.cur > 0 { // skip first delay
-		time.Sleep(i.delay)
-	}
-
-	cur := i.files[i.cur]
-	i.cur++
-
-	file, err := i.next(ctx, cur)
-	if err != nil {
-		i.err = err
-		return false
-	}
-
-	i.file = file
-	return true
-}
-
-func (i *iter) next(ctx context.Context, cur *File) (*iterElem, error) {
-	file, err := i.resolveFile(cur.File)
-	if err != nil {
-		return nil, errors.Wrap(err, "resolve file")
-	}
-
-	env := exprEnv(ctx, cur)
-
-	to, thread, err := i.resolveDest(ctx, env)
-	if err != nil {
-		return nil, errors.Wrap(err, "resolve destination")
-	}
-
-	caption, err := i.resolveCaption(env)
-	if err != nil {
-		return nil, errors.Wrap(err, "resolve caption")
-	}
-
-	thumb, err := i.resolveThumb(cur.Thumb)
-	if err != nil {
-		return nil, errors.Wrap(err, "resolve thumbnail")
-	}
-
-	return &iterElem{
-		file:    file,
-		thumb:   thumb,
-		to:      to,
-		caption: caption,
-		thread:  thread,
-
-		asPhoto: i.photo,
-		remove:  i.remove,
-	}, nil
-}
-
-func (i *iter) resolveFile(path string) (*uploaderFile, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrap(err, "open file")
-	}
-
-	stat, err := f.Stat()
-	if err != nil {
-		return nil, errors.Wrap(err, "stat file")
-	}
-
-	return &uploaderFile{
-		File: f,
-		size: stat.Size(),
-	}, nil
-}
-
-func (i *iter) resolveDest(ctx context.Context, env Env) (peers.Peer, int, error) {
-	if i.chat != "" { // compatible with old version
-		to, err := i.resolvePeer(ctx, i.chat)
+func (r *taskResolver) resolveDest(ctx context.Context, env Env) (peers.Peer, int, error) {
+	if r.chat != "" {
+		to, err := r.resolvePeer(ctx, r.chat)
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "resolve chat")
 		}
-
-		return to, i.topic, nil
+		return to, r.topic, nil
 	}
 
-	// message routing
-	result, err := texpr.Run(i.to, env)
+	result, err := texpr.Run(r.to, env)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "parse expression")
 	}
@@ -167,20 +86,15 @@ func (i *iter) resolveDest(ctx context.Context, env Env) (peers.Peer, int, error
 		thread int
 	)
 
-	switch r := result.(type) {
+	switch out := result.(type) {
 	case string:
-		// pure chat, no reply to, which is a compatible with old version
-		// and a convenient way to send message to self
-		to, err = i.resolvePeer(ctx, r)
+		to, err = r.resolvePeer(ctx, out)
 	case map[string]interface{}:
-		// chat with reply to topic or message
 		var d dest
-
-		if err = mapstructure.WeakDecode(r, &d); err != nil {
+		if err = mapstructure.WeakDecode(out, &d); err != nil {
 			return nil, 0, errors.Wrapf(err, "decode dest: %v", result)
 		}
-
-		to, err = i.resolvePeer(ctx, d.Peer)
+		to, err = r.resolvePeer(ctx, d.Peer)
 		thread = d.Thread
 	default:
 		return nil, 0, errors.Errorf("message router must return string or dest: %T", result)
@@ -193,65 +107,93 @@ func (i *iter) resolveDest(ctx context.Context, env Env) (peers.Peer, int, error
 	return to, thread, nil
 }
 
-func (i *iter) resolvePeer(ctx context.Context, peer string) (peers.Peer, error) {
-	if peer == "" { // self
-		return i.manager.Self(ctx)
+func (r *taskResolver) resolvePeer(ctx context.Context, peer string) (peers.Peer, error) {
+	if peer == "" {
+		return r.manager.Self(ctx)
 	}
-
-	return tutil.GetInputPeer(ctx, i.manager, peer)
+	return tutil.GetInputPeer(ctx, r.manager, peer)
 }
 
-func (i *iter) resolveCaption(env Env) (*entity.Builder, error) {
-	// parse caption
-	captionStr, err := texpr.Run(i.caption, env)
+func (r *taskResolver) resolveCaption(env Env) (string, []tg.MessageEntityClass, error) {
+	captionResult, err := texpr.Run(r.caption, env)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse caption")
+		return "", nil, errors.Wrap(err, "parse caption")
 	}
 
-	r, ok := captionStr.(string)
+	raw, ok := captionResult.(string)
 	if !ok {
-		return nil, errors.Errorf("caption must return string, got %T", captionStr)
+		return "", nil, errors.Errorf("caption must return string, got %T", captionResult)
 	}
 
-	caption := &entity.Builder{}
-	if len(r) > 0 {
-		if err = html.HTML(strings.NewReader(r), caption, html.Options{
-			UserResolver:          nil,
-			DisableTelegramEscape: false,
-		}); err != nil {
-			return nil, errors.Wrap(err, "parse caption HTML")
-		}
+	if raw == "" {
+		return "", nil, nil
 	}
 
-	return caption, nil
+	eb := &entity.Builder{}
+	if err = html.HTML(strings.NewReader(raw), eb, html.Options{
+		UserResolver:          nil,
+		DisableTelegramEscape: false,
+	}); err != nil {
+		return "", nil, errors.Wrap(err, "parse caption HTML")
+	}
+
+	msg, entities := eb.Complete()
+	return msg, entities, nil
 }
 
-func (i *iter) resolveThumb(path string) (*uploaderFile, error) {
-	if path == "" {
-		return nil, nil
+type iter struct {
+	tasks []*uploadTask
+	delay time.Duration
+
+	cur  int
+	err  error
+	elem uploader.Elem
+}
+
+func newIter(tasks []*uploadTask, delay time.Duration) *iter {
+	return &iter{
+		tasks: tasks,
+		delay: delay,
+	}
+}
+
+func (i *iter) Next(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		i.err = ctx.Err()
+		return false
+	default:
 	}
 
-	// has thumbnail
-	mime, err := mimetype.DetectFile(path)
-	if err != nil || !mediautil.IsImage(mime.String()) { // TODO(iyear): jpg only
-		return nil, errors.Wrapf(err, "invalid thumbnail file: %v", path)
+	if i.cur >= len(i.tasks) || i.err != nil {
+		return false
 	}
 
-	thumb, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrap(err, "open thumbnail file")
+	if i.delay > 0 && i.cur > 0 {
+		time.Sleep(i.delay)
 	}
 
-	return &uploaderFile{
-		File: thumb,
-		size: 0,
-	}, nil
+	task := i.tasks[i.cur]
+	i.cur++
+
+	i.elem = &iterElem{
+		task: task,
+	}
+	return true
 }
 
 func (i *iter) Value() uploader.Elem {
-	return i.file
+	return i.elem
 }
 
 func (i *iter) Err() error {
 	return i.err
+}
+
+func ext(path string) string {
+	return strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
+}
+
+func isDetectVideoExt(path string) bool {
+	return slices.Contains([]string{"mp4", "m4v", "mov"}, ext(path))
 }

--- a/app/up/prepare.go
+++ b/app/up/prepare.go
@@ -1,0 +1,477 @@
+package up
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/gabriel-vasile/mimetype"
+	"github.com/go-faster/errors"
+	"github.com/gotd/td/telegram/peers"
+	"github.com/gotd/td/tg"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/iyear/tdl/core/uploader"
+	"github.com/iyear/tdl/core/util/mediautil"
+)
+
+const (
+	maxThumbSizeBytes = 200 * 1024
+	maxThumbWidth     = 320
+	maxThumbHeight    = 320
+)
+
+var albumPattern = regexp.MustCompile(`^(.+?)_(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2}-\d{2})`)
+
+type preparedItem struct {
+	media    uploader.MediaDescriptor
+	peer     peers.Peer
+	thread   int
+	entities []tg.MessageEntityClass
+	size     int64
+}
+
+type videoMetadata struct {
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
+	Duration int    `json:"duration"`
+	Rotation int    `json:"rotation"`
+	Codec    string `json:"codec"`
+	Bitrate  int    `json:"bitrate"`
+}
+
+type ffprobeOutput struct {
+	Streams []struct {
+		CodecType string `json:"codec_type"`
+		CodecName string `json:"codec_name"`
+		Width     int    `json:"width"`
+		Height    int    `json:"height"`
+		Duration  string `json:"duration"`
+		BitRate   string `json:"bit_rate"`
+		Tags      struct {
+			Rotate string `json:"rotate"`
+		} `json:"tags"`
+		SideDataList []struct {
+			Rotation int `json:"rotation"`
+		} `json:"side_data_list"`
+	} `json:"streams"`
+	Format struct {
+		Duration string `json:"duration"`
+		BitRate  string `json:"bit_rate"`
+	} `json:"format"`
+}
+
+func prepareUploadTasks(ctx context.Context, files []*File, resolver *taskResolver, opts Options, limit int) ([]*uploadTask, error) {
+	items := make([]*preparedItem, len(files))
+	wg, wgctx := errgroup.WithContext(ctx)
+	wg.SetLimit(max(1, limit))
+
+	for idx, f := range files {
+		idx, f := idx, f
+		wg.Go(func() error {
+			peer, thread, caption, entities, err := resolver.resolve(wgctx, f)
+			if err != nil {
+				return err
+			}
+
+			mime, err := mimetype.DetectFile(f.File)
+			if err != nil {
+				return errors.Wrapf(err, "detect file mime: %s", f.File)
+			}
+
+			stat, err := os.Stat(f.File)
+			if err != nil {
+				return errors.Wrapf(err, "stat file: %s", f.File)
+			}
+
+			mediaType := decideMediaType(f.File, mime.String(), opts)
+			media := uploader.MediaDescriptor{
+				Path:      f.File,
+				Thumb:     f.Thumb,
+				Mime:      mime.String(),
+				Streaming: false,
+				Caption:   caption,
+				AlbumID:   albumGroupID(f.File),
+				Type:      mediaType,
+			}
+
+			if mediaType == uploader.MediaTypeVideo {
+				hash, err := fileSHA256(f.File)
+				if err != nil {
+					return errors.Wrap(err, "hash video")
+				}
+
+				meta, err := loadOrExtractMetadata(f.File, hash)
+				if err != nil {
+					return errors.Wrapf(err, "extract metadata: %s", f.File)
+				}
+				media.Width = meta.Width
+				media.Height = meta.Height
+				media.Duration = meta.Duration
+				media.Streaming = true
+
+				thumb, err := loadOrGenerateThumb(f.File, f.Thumb, hash)
+				if err != nil {
+					return errors.Wrapf(err, "prepare thumbnail: %s", f.File)
+				}
+				media.Thumb = thumb
+			}
+
+			items[idx] = &preparedItem{
+				media:    media,
+				peer:     peer,
+				thread:   thread,
+				entities: entities,
+				size:     stat.Size(),
+			}
+			return nil
+		})
+	}
+
+	if err := wg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return buildTasks(items, opts), nil
+}
+
+func decideMediaType(path, mime string, opts Options) uploader.MediaType {
+	switch {
+	case mediautil.IsImage(mime) && opts.Photo && mime != "image/webp":
+		return uploader.MediaTypePhoto
+	case opts.Video && (mediautil.IsVideo(mime) || isDetectVideoExt(path)):
+		return uploader.MediaTypeVideo
+	case opts.DetectVideo && isDetectVideoExt(path):
+		return uploader.MediaTypeVideo
+	default:
+		return uploader.MediaTypeDocument
+	}
+}
+
+func buildTasks(items []*preparedItem, opts Options) []*uploadTask {
+	if !opts.Album {
+		ret := make([]*uploadTask, 0, len(items))
+		for _, item := range items {
+			label := fmt.Sprintf("%s -> %s(%d)", item.media.Path, item.peer.VisibleName(), item.peer.ID())
+			ret = append(ret, &uploadTask{
+				media:      []uploader.MediaDescriptor{item.media},
+				to:         item.peer,
+				thread:     item.thread,
+				remove:     opts.Remove,
+				paths:      []string{item.media.Path},
+				totalSize:  item.size,
+				label:      label,
+				entityByID: map[string][]tg.MessageEntityClass{item.media.Path: item.entities},
+			})
+		}
+		return ret
+	}
+
+	grouped := map[string][]*preparedItem{}
+	order := make([]string, 0)
+	for _, item := range items {
+		album := item.media.AlbumID
+		if album == "" {
+			album = item.media.Path
+		}
+		k := fmt.Sprintf("%s|%d|%d", album, item.peer.ID(), item.thread)
+		if _, ok := grouped[k]; !ok {
+			order = append(order, k)
+		}
+		grouped[k] = append(grouped[k], item)
+	}
+
+	ret := make([]*uploadTask, 0, len(items))
+	for _, k := range order {
+		g := grouped[k]
+		sort.Slice(g, func(i, j int) bool {
+			return g[i].media.Path < g[j].media.Path
+		})
+
+		for start := 0; start < len(g); start += 10 {
+			end := min(start+10, len(g))
+			chunk := g[start:end]
+
+			media := make([]uploader.MediaDescriptor, 0, len(chunk))
+			paths := make([]string, 0, len(chunk))
+			entityByID := make(map[string][]tg.MessageEntityClass, len(chunk))
+			totalSize := int64(0)
+
+			for i, item := range chunk {
+				m := item.media
+				entities := item.entities
+				if len(chunk) > 1 && i > 0 {
+					m.Caption = ""
+					entities = nil
+				}
+				media = append(media, m)
+				paths = append(paths, m.Path)
+				totalSize += item.size
+				entityByID[m.Path] = entities
+			}
+
+			ret = append(ret, &uploadTask{
+				media:      media,
+				to:         chunk[0].peer,
+				thread:     chunk[0].thread,
+				remove:     opts.Remove,
+				paths:      paths,
+				totalSize:  totalSize,
+				label:      fmt.Sprintf("%s (%d itens) -> %s(%d)", media[0].AlbumID, len(media), chunk[0].peer.VisibleName(), chunk[0].peer.ID()),
+				entityByID: entityByID,
+			})
+		}
+	}
+
+	return ret
+}
+
+func albumGroupID(path string) string {
+	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	m := albumPattern.FindStringSubmatch(name)
+	if len(m) != 4 {
+		return ""
+	}
+	return fmt.Sprintf("%s_%s", m[1], m[2])
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", errors.Wrap(err, "open file")
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err = io.Copy(h, f); err != nil {
+		return "", errors.Wrap(err, "hash file")
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func cacheDirs() (thumbs string, metadata string, err error) {
+	base := ".cache"
+	thumbs = filepath.Join(base, "thumbs")
+	metadata = filepath.Join(base, "metadata")
+	if err = os.MkdirAll(thumbs, 0o755); err != nil {
+		return "", "", err
+	}
+	if err = os.MkdirAll(metadata, 0o755); err != nil {
+		return "", "", err
+	}
+	return thumbs, metadata, nil
+}
+
+func loadOrExtractMetadata(path, hash string) (videoMetadata, error) {
+	_, metadataDir, err := cacheDirs()
+	if err != nil {
+		return videoMetadata{}, errors.Wrap(err, "prepare cache dir")
+	}
+
+	cachePath := filepath.Join(metadataDir, hash+".json")
+	if data, readErr := os.ReadFile(cachePath); readErr == nil {
+		var meta videoMetadata
+		if jsonErr := json.Unmarshal(data, &meta); jsonErr == nil {
+			return meta, nil
+		}
+	}
+
+	meta, err := extractVideoMetadata(path)
+	if err != nil {
+		return videoMetadata{}, err
+	}
+
+	raw, err := json.Marshal(meta)
+	if err == nil {
+		_ = os.WriteFile(cachePath, raw, 0o644)
+	}
+	return meta, nil
+}
+
+func extractVideoMetadata(path string) (videoMetadata, error) {
+	out, err := exec.Command("ffprobe", "-v", "quiet", "-print_format", "json", "-show_streams", "-show_format", path).Output()
+	if err != nil {
+		return videoMetadata{}, errors.Wrap(err, "run ffprobe")
+	}
+
+	var parsed ffprobeOutput
+	if err = json.Unmarshal(out, &parsed); err != nil {
+		return videoMetadata{}, errors.Wrap(err, "decode ffprobe output")
+	}
+
+	meta := videoMetadata{}
+	for _, s := range parsed.Streams {
+		if s.CodecType != "video" {
+			continue
+		}
+		meta.Width = s.Width
+		meta.Height = s.Height
+		meta.Duration = parseDurationSeconds(s.Duration, parsed.Format.Duration)
+		meta.Codec = s.CodecName
+		meta.Bitrate = parseInt(s.BitRate, parseInt(parsed.Format.BitRate, 0))
+		meta.Rotation = parseRotation(s.Tags.Rotate, s.SideDataList)
+		break
+	}
+
+	if meta.Duration == 0 {
+		meta.Duration = parseDurationSeconds("", parsed.Format.Duration)
+	}
+
+	return meta, nil
+}
+
+func parseRotation(tag string, sideData []struct {
+	Rotation int `json:"rotation"`
+}) int {
+	if tag != "" {
+		if v, err := strconv.Atoi(tag); err == nil {
+			return v
+		}
+	}
+	if len(sideData) > 0 {
+		return sideData[0].Rotation
+	}
+	return 0
+}
+
+func parseDurationSeconds(primary, fallback string) int {
+	toInt := func(v string) int {
+		if v == "" {
+			return 0
+		}
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0
+		}
+		return int(f + 0.5)
+	}
+	if s := toInt(primary); s > 0 {
+		return s
+	}
+	return toInt(fallback)
+}
+
+func parseInt(v string, def int) int {
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return def
+	}
+	return int(n)
+}
+
+func loadOrGenerateThumb(videoPath, explicitThumb, hash string) (string, error) {
+	thumbsDir, _, err := cacheDirs()
+	if err != nil {
+		return "", errors.Wrap(err, "prepare cache dir")
+	}
+
+	cachePath := filepath.Join(thumbsDir, hash+".jpg")
+	if ok, _ := validateThumb(cachePath); ok {
+		return cachePath, nil
+	}
+
+	source := explicitThumb
+	if source == "" {
+		source = sidecarThumb(videoPath)
+	}
+
+	if source == "" {
+		raw := filepath.Join(thumbsDir, hash+"_raw.jpg")
+		_ = os.Remove(raw)
+		if err = exec.Command("ffmpeg", "-y", "-ss", "00:00:02", "-i", videoPath, "-vframes", "1", "-vf", "scale=320:320:force_original_aspect_ratio=decrease", "-q:v", "2", raw).Run(); err != nil {
+			return "", errors.Wrap(err, "generate thumbnail with ffmpeg")
+		}
+		source = raw
+	}
+
+	if err = normalizeThumb(source, cachePath); err != nil {
+		return "", errors.Wrap(err, "normalize thumbnail")
+	}
+
+	return cachePath, nil
+}
+
+func sidecarThumb(videoPath string) string {
+	base := strings.TrimSuffix(videoPath, filepath.Ext(videoPath))
+	for _, ext := range []string{".jpg", ".jpeg", ".png"} {
+		candidate := base + ext
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func normalizeThumb(inputPath, outputPath string) error {
+	if filepath.Clean(inputPath) == filepath.Clean(outputPath) {
+		if ok, err := validateThumb(outputPath); ok {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+
+	qualityCandidates := []int{2, 4, 8, 12, 16, 20, 24, 28, 31}
+	for _, q := range qualityCandidates {
+		cmd := exec.Command(
+			"ffmpeg", "-y", "-i", inputPath,
+			"-vframes", "1",
+			"-vf", "scale=320:320:force_original_aspect_ratio=decrease",
+			"-q:v", strconv.Itoa(q),
+			"-f", "image2",
+			outputPath,
+		)
+		if err := cmd.Run(); err != nil {
+			continue
+		}
+
+		if ok, _ := validateThumb(outputPath); ok {
+			return nil
+		}
+	}
+
+	return errors.New("unable to create valid thumbnail <=200KB and <=320x320 JPEG")
+}
+
+func validateThumb(path string) (bool, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if stat.Size() > maxThumbSizeBytes {
+		return false, nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	cfg, format, err := image.DecodeConfig(f)
+	if err != nil {
+		return false, err
+	}
+	if !slices.Contains([]string{"jpeg", "jpg"}, strings.ToLower(format)) {
+		return false, nil
+	}
+	if cfg.Width > maxThumbWidth || cfg.Height > maxThumbHeight {
+		return false, nil
+	}
+	return true, nil
+}

--- a/app/up/prepare_test.go
+++ b/app/up/prepare_test.go
@@ -1,0 +1,56 @@
+package up
+
+import (
+	"testing"
+
+	"github.com/iyear/tdl/core/uploader"
+)
+
+func TestAlbumGroupID(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "alice_2026-07-21_10-00-00.mp4", want: "alice_2026-07-21"},
+		{path: "bob_2026-07-21_11-30-00.mov", want: "bob_2026-07-21"},
+		{path: "random.mp4", want: ""},
+	}
+
+	for _, tt := range tests {
+		if got := albumGroupID(tt.path); got != tt.want {
+			t.Fatalf("albumGroupID(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestIsDetectVideoExt(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "a.mp4", want: true},
+		{path: "a.M4V", want: true},
+		{path: "a.mov", want: true},
+		{path: "a.mkv", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := isDetectVideoExt(tt.path); got != tt.want {
+			t.Fatalf("isDetectVideoExt(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestDecideMediaType(t *testing.T) {
+	opts := Options{Photo: true, Video: false, DetectVideo: true}
+
+	if got := decideMediaType("x.mp4", "application/octet-stream", opts); got != uploader.MediaTypeVideo {
+		t.Fatalf("detect-video expected video, got %s", got)
+	}
+	if got := decideMediaType("x.jpg", "image/jpeg", opts); got != uploader.MediaTypePhoto {
+		t.Fatalf("photo expected photo, got %s", got)
+	}
+	if got := decideMediaType("x.bin", "application/octet-stream", opts); got != uploader.MediaTypeDocument {
+		t.Fatalf("default expected document, got %s", got)
+	}
+}

--- a/app/up/progress.go
+++ b/app/up/progress.go
@@ -1,12 +1,9 @@
 package up
 
 import (
-	"fmt"
-	"os"
 	"sync"
 
 	"github.com/fatih/color"
-	"github.com/go-faster/errors"
 	pw "github.com/jedib0t/go-pretty/v6/progress"
 
 	"github.com/iyear/tdl/core/uploader"
@@ -20,8 +17,7 @@ type progress struct {
 }
 
 type tuple struct {
-	name string
-	to   int64
+	label string
 }
 
 func newProgress(p pw.Writer) *progress {
@@ -32,7 +28,7 @@ func newProgress(p pw.Writer) *progress {
 }
 
 func (p *progress) OnAdd(elem uploader.Elem) {
-	tracker := prog.AppendTracker(p.pw, utils.Byte.FormatBinaryBytes, p.processMessage(elem), elem.File().Size())
+	tracker := prog.AppendTracker(p.pw, utils.Byte.FormatBinaryBytes, p.processMessage(elem), elem.TotalSize())
 	p.trackers.Store(p.tuple(elem), tracker)
 }
 
@@ -53,38 +49,11 @@ func (p *progress) OnDone(elem uploader.Elem, err error) {
 		return
 	}
 	t := tracker.(*pw.Tracker)
-	e := elem.(*iterElem)
-
-	if err := p.closeFile(e); err != nil {
-		p.fail(t, elem, errors.Wrap(err, "close file"))
-		return
-	}
 
 	if err != nil {
-		p.fail(t, elem, errors.Wrap(err, "progress"))
+		p.fail(t, elem, err)
 		return
 	}
-
-	if e.remove {
-		if err := os.Remove(e.file.File.Name()); err != nil {
-			p.fail(t, elem, errors.Wrap(err, "remove file"))
-			return
-		}
-	}
-}
-
-func (p *progress) closeFile(e *iterElem) error {
-	if err := e.file.Close(); err != nil {
-		return errors.Wrap(err, "close file")
-	}
-
-	if e.thumb != nil {
-		if err := e.thumb.Close(); err != nil {
-			return errors.Wrap(err, "close thumb")
-		}
-	}
-
-	return nil
 }
 
 func (p *progress) fail(t *pw.Tracker, elem uploader.Elem, err error) {
@@ -93,7 +62,7 @@ func (p *progress) fail(t *pw.Tracker, elem uploader.Elem, err error) {
 }
 
 func (p *progress) tuple(elem uploader.Elem) tuple {
-	return tuple{elem.(*iterElem).file.File.Name(), elem.(*iterElem).to.ID()}
+	return tuple{label: elem.Label()}
 }
 
 func (p *progress) processMessage(elem uploader.Elem) string {
@@ -101,6 +70,5 @@ func (p *progress) processMessage(elem uploader.Elem) string {
 }
 
 func (p *progress) elemString(elem uploader.Elem) string {
-	e := elem.(*iterElem)
-	return fmt.Sprintf("%s -> %s(%d)", e.file.File.Name(), e.to.VisibleName(), e.to.ID())
+	return elem.Label()
 }

--- a/app/up/up.go
+++ b/app/up/up.go
@@ -32,15 +32,18 @@ import (
 )
 
 type Options struct {
-	Chat     string
-	Thread   int
-	To       string
-	Paths    []string
-	Includes []string
-	Excludes []string
-	Remove   bool
-	Photo    bool
-	Caption  string
+	Chat        string
+	Thread      int
+	To          string
+	Paths       []string
+	Includes    []string
+	Excludes    []string
+	Remove      bool
+	Photo       bool
+	Video       bool
+	Album       bool
+	DetectVideo bool
+	Caption     string
 }
 
 type Env struct {
@@ -49,6 +52,11 @@ type Env struct {
 	FileExt   string `comment:"File extension"`
 	ThumbPath string `comment:"Thumbnail path"`
 	MIME      string `comment:"File mime type"`
+}
+
+type File struct {
+	File  string
+	Thumb string
 }
 
 func Run(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts Options) (rerr error) {
@@ -88,8 +96,21 @@ func Run(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts Opti
 		return errors.Wrap(err, "get caption")
 	}
 
+	resolver := &taskResolver{
+		to:      to,
+		caption: caption,
+		chat:    opts.Chat,
+		topic:   opts.Thread,
+		manager: manager,
+	}
+
+	tasks, err := prepareUploadTasks(ctx, files, resolver, opts, viper.GetInt(consts.FlagLimit))
+	if err != nil {
+		return errors.Wrap(err, "prepare upload tasks")
+	}
+
 	upProgress := prog.New(utils.Byte.FormatBinaryBytes)
-	upProgress.SetNumTrackersExpected(len(files))
+	upProgress.SetNumTrackersExpected(len(tasks))
 	if !viper.GetBool(consts.FlagDisableProgressPS) {
 		prog.EnablePS(ctx, upProgress)
 	}
@@ -97,7 +118,7 @@ func Run(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts Opti
 	options := uploader.Options{
 		Client:   pool.Default(ctx),
 		Threads:  viper.GetInt(consts.FlagThreads),
-		Iter:     newIter(files, to, caption, opts.Chat, opts.Thread, opts.Photo, opts.Remove, viper.GetDuration(consts.FlagDelay), manager),
+		Iter:     newIter(tasks, viper.GetDuration(consts.FlagDelay)),
 		Progress: newProgress(upProgress),
 	}
 

--- a/app/up/walk.go
+++ b/app/up/walk.go
@@ -28,6 +28,9 @@ func walk(paths, includes, excludes []string) ([]*File, error) {
 
 			// process include and exclude
 			ext := filepath.Ext(path)
+			if isSidecarThumb(path, ext) {
+				return nil
+			}
 			if _, ok := includesMap[ext]; len(includesMap) > 0 && !ok {
 				return nil
 			}
@@ -36,9 +39,18 @@ func walk(paths, includes, excludes []string) ([]*File, error) {
 			}
 
 			f := File{File: path}
-			t := strings.TrimRight(path, filepath.Ext(path)) + consts.UploadThumbExt
+			base := strings.TrimSuffix(path, filepath.Ext(path))
+			t := base + consts.UploadThumbExt
 			if fsutil.PathExists(t) {
 				f.Thumb = t
+			} else {
+				for _, ext := range []string{".jpg", ".jpeg", ".png"} {
+					candidate := base + ext
+					if fsutil.PathExists(candidate) {
+						f.Thumb = candidate
+						break
+					}
+				}
 			}
 
 			files = append(files, &f)
@@ -50,4 +62,20 @@ func walk(paths, includes, excludes []string) ([]*File, error) {
 	}
 
 	return files, nil
+}
+
+func isSidecarThumb(path, ext string) bool {
+	switch strings.ToLower(ext) {
+	case ".jpg", ".jpeg", ".png":
+	default:
+		return false
+	}
+
+	base := strings.TrimSuffix(path, ext)
+	for _, videoExt := range []string{".mp4", ".m4v", ".mov"} {
+		if fsutil.PathExists(base + videoExt) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -47,6 +47,9 @@ func NewUpload() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&opts.Excludes, exclude, "e", []string{}, "exclude the specified file extensions")
 	cmd.Flags().BoolVar(&opts.Remove, "rm", false, "remove the uploaded files after uploading")
 	cmd.Flags().BoolVar(&opts.Photo, "photo", false, "upload the image as a photo instead of a file")
+	cmd.Flags().BoolVar(&opts.Video, "video", false, "upload videos as streamable video media instead of files")
+	cmd.Flags().BoolVar(&opts.DetectVideo, "detect-video", false, "treat files with mp4/m4v/mov extension as videos")
+	cmd.Flags().BoolVar(&opts.Album, "album", false, "group files by model/date and upload as albums")
 	cmd.Flags().StringVar(&opts.Caption, "caption", `"<code>"+FileName+"</code> - <code>"+MIME+"</code>"`, "caption for the uploaded media")
 
 	// completion and validation

--- a/core/uploader/iter.go
+++ b/core/uploader/iter.go
@@ -2,7 +2,6 @@ package uploader
 
 import (
 	"context"
-	"io"
 
 	"github.com/gotd/td/tg"
 )
@@ -13,17 +12,34 @@ type Iter interface {
 	Err() error
 }
 
-type File interface {
-	io.ReadSeeker
-	Name() string
-	Size() int64
+type MediaType string
+
+const (
+	MediaTypePhoto    MediaType = "photo"
+	MediaTypeVideo    MediaType = "video"
+	MediaTypeDocument MediaType = "document"
+)
+
+type MediaDescriptor struct {
+	Path      string
+	Thumb     string
+	Width     int
+	Height    int
+	Duration  int
+	Mime      string
+	Streaming bool
+	Caption   string
+	AlbumID   string
+	Type      MediaType
 }
 
 type Elem interface {
-	File() File
-	Thumb() (File, bool)
-	Caption() (string, []tg.MessageEntityClass)
+	Media() []MediaDescriptor
 	To() tg.InputPeerClass
 	Thread() int
-	AsPhoto() bool
+	Remove() bool
+	Paths() []string
+	TotalSize() int64
+	Label() string
+	CaptionEntities(media MediaDescriptor) []tg.MessageEntityClass
 }

--- a/core/uploader/uploader.go
+++ b/core/uploader/uploader.go
@@ -2,21 +2,20 @@ package uploader
 
 import (
 	"context"
-	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"time"
 
-	"github.com/gabriel-vasile/mimetype"
 	"github.com/go-faster/errors"
 	"github.com/gotd/td/telegram/message"
 	"github.com/gotd/td/telegram/message/entity"
 	"github.com/gotd/td/telegram/message/styling"
-	"github.com/gotd/td/telegram/uploader"
+	tduploader "github.com/gotd/td/telegram/uploader"
 	"github.com/gotd/td/tg"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/iyear/tdl/core/util/fsutil"
-	"github.com/iyear/tdl/core/util/mediautil"
 )
 
 // MaxPartSize refer to https://core.telegram.org/api/files#uploading-files
@@ -24,6 +23,7 @@ const MaxPartSize = 512 * 1024
 
 type Uploader struct {
 	opts Options
+	rand *rand.Rand
 }
 
 type Options struct {
@@ -34,7 +34,10 @@ type Options struct {
 }
 
 func New(o Options) *Uploader {
-	return &Uploader{opts: o}
+	return &Uploader{
+		opts: o,
+		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
 }
 
 func (u *Uploader) Upload(ctx context.Context, limit int) error {
@@ -44,19 +47,15 @@ func (u *Uploader) Upload(ctx context.Context, limit int) error {
 	for u.opts.Iter.Next(wgctx) {
 		elem := u.opts.Iter.Value()
 
-		wg.Go(func() (rerr error) {
+		wg.Go(func() error {
 			u.opts.Progress.OnAdd(elem)
-			defer func() { u.opts.Progress.OnDone(elem, rerr) }()
 
-			if err := u.upload(wgctx, elem); err != nil {
-				// canceled by user, so we directly return error to stop all
-				if errors.Is(err, context.Canceled) {
-					return errors.Wrap(err, "upload")
-				}
+			err := u.upload(wgctx, elem)
+			u.opts.Progress.OnDone(elem, err)
 
-				// don't return error, just log it
+			if err != nil && errors.Is(err, context.Canceled) {
+				return errors.Wrap(err, "upload")
 			}
-
 			return nil
 		})
 	}
@@ -68,38 +67,48 @@ func (u *Uploader) Upload(ctx context.Context, limit int) error {
 	return wg.Wait()
 }
 
-func (u *Uploader) upload(ctx context.Context, elem Elem) error {
+func (u *Uploader) upload(ctx context.Context, elem Elem) (rerr error) {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
 
-	up := uploader.NewUploader(u.opts.Client).
-		WithPartSize(MaxPartSize).
-		WithThreads(u.opts.Threads).
-		WithProgress(&wrapProcess{
-			elem:    elem,
-			process: u.opts.Progress,
-		})
+	media := elem.Media()
+	if len(media) == 0 {
+		return errors.New("empty media")
+	}
 
-	f, err := up.Upload(ctx, uploader.NewUpload(elem.File().Name(), elem.File(), elem.File().Size()))
+	if len(media) == 1 {
+		if err := u.sendSingle(ctx, elem, media[0]); err != nil {
+			return err
+		}
+	} else {
+		if err := u.sendAlbum(ctx, elem, media); err != nil {
+			return err
+		}
+	}
+
+	if elem.Remove() {
+		for _, p := range elem.Paths() {
+			if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return errors.Wrapf(err, "remove file: %s", p)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (u *Uploader) sendSingle(ctx context.Context, elem Elem, media MediaDescriptor) error {
+	ap := newAlbumProgress(elem, u.opts.Progress)
+	inputMedia, _, err := u.buildInputMedia(ctx, elem, media, ap)
 	if err != nil {
-		return errors.Wrap(err, "upload file")
+		return errors.Wrap(err, "build media")
 	}
 
-	if _, err = elem.File().Seek(0, io.SeekStart); err != nil {
-		return errors.Wrap(err, "seek file")
-	}
-	mime, err := mimetype.DetectReader(elem.File())
-	if err != nil {
-		return errors.Wrap(err, "detect mime")
-	}
-
-	// here convert underlying entities to formatters for message caption
 	caption := styling.Custom(func(eb *entity.Builder) error {
-		msg, entities := elem.Caption()
-		eb.Format(msg, lo.Map(entities, func(item tg.MessageEntityClass, _ int) entity.Formatter {
+		eb.Format(media.Caption, lo.Map(elem.CaptionEntities(media), func(item tg.MessageEntityClass, _ int) entity.Formatter {
 			return func(_, _ int) tg.MessageEntityClass {
 				return item
 			}
@@ -107,49 +116,260 @@ func (u *Uploader) upload(ctx context.Context, elem Elem) error {
 		return nil
 	})
 
-	doc := message.UploadedDocument(f, caption).MIME(mime.String()).Filename(elem.File().Name())
-	// upload thumbnail TODO(iyear): maybe still unavailable
-	if thumb, ok := elem.Thumb(); ok {
-		if thumbFile, err := uploader.NewUploader(u.opts.Client).
-			FromReader(ctx, thumb.Name(), thumb); err == nil {
-			doc = doc.Thumb(thumbFile)
+	switch m := inputMedia.(type) {
+	case *tg.InputMediaUploadedPhoto:
+		_, err = message.NewSender(u.opts.Client).
+			To(elem.To()).
+			Reply(elem.Thread()).
+			Media(ctx, message.UploadedPhoto(m.File, caption))
+		if err != nil {
+			return errors.Wrap(err, "send photo")
 		}
-	}
-
-	var media message.MediaOption = doc
-
-	switch {
-	case mediautil.IsImage(mime.String()) && elem.AsPhoto():
-		// webp should be uploaded as document
-		if mime.String() == "image/webp" {
-			break
+	case *tg.InputMediaUploadedDocument:
+		doc := message.UploadedDocument(m.File, caption).MIME(m.MimeType).Filename(filepath.Base(media.Path))
+		if m.Thumb != nil {
+			doc = doc.Thumb(m.Thumb)
 		}
-		// upload as photo
-		media = message.UploadedPhoto(f, caption)
-	case mediautil.IsVideo(mime.String()):
-		// reset reader
-		if _, err = elem.File().Seek(0, io.SeekStart); err != nil {
-			return errors.Wrap(err, "seek file")
+		var mediaOption message.MediaOption = doc
+		if media.Type == MediaTypeVideo {
+			mediaOption = doc.Video().
+				SupportsStreaming().
+				Duration(time.Duration(media.Duration)*time.Second).
+				Resolution(media.Width, media.Height)
 		}
-		if dur, w, h, err := mediautil.GetMP4Info(elem.File()); err == nil {
-			// #132. There may be some errors, but we can still upload the file
-			media = doc.Video().
-				Duration(time.Duration(dur)*time.Second).
-				Resolution(w, h).
-				SupportsStreaming()
+		_, err = message.NewSender(u.opts.Client).
+			To(elem.To()).
+			Reply(elem.Thread()).
+			Media(ctx, mediaOption)
+		if err != nil {
+			return errors.Wrap(err, "send document")
 		}
-	case mediautil.IsAudio(mime.String()):
-		media = doc.Audio().Title(fsutil.GetNameWithoutExt(elem.File().Name()))
-	}
-
-	_, err = message.NewSender(u.opts.Client).
-		WithUploader(up).
-		To(elem.To()).
-		Reply(elem.Thread()).
-		Media(ctx, media)
-	if err != nil {
-		return errors.Wrap(err, "send message")
+	default:
+		return errors.Errorf("unsupported media %T", inputMedia)
 	}
 
 	return nil
+}
+
+func (u *Uploader) sendAlbum(ctx context.Context, elem Elem, mediaList []MediaDescriptor) error {
+	items := make([]tg.InputSingleMedia, len(mediaList))
+	randomIDs := make([]int64, len(mediaList))
+	for i := range randomIDs {
+		randomIDs[i] = u.rand.Int63()
+	}
+
+	ap := newAlbumProgress(elem, u.opts.Progress)
+	peer := elem.To()
+	wg, wgctx := errgroup.WithContext(ctx)
+	for idx, media := range mediaList {
+		idx, media := idx, media
+		wg.Go(func() error {
+			uploaded, entities, err := u.buildInputMedia(wgctx, elem, media, ap)
+			if err != nil {
+				return errors.Wrap(err, "build album media")
+			}
+
+			committed, err := u.commitAlbumMedia(wgctx, peer, uploaded)
+			if err != nil {
+				return errors.Wrap(err, "commit album media")
+			}
+
+			item := tg.InputSingleMedia{
+				Media:    committed,
+				RandomID: randomIDs[idx],
+				Message:  media.Caption,
+				Entities: entities,
+			}
+			item.SetFlags()
+			items[idx] = item
+			return nil
+		})
+	}
+	if err := wg.Wait(); err != nil {
+		return err
+	}
+
+	req := &tg.MessagesSendMultiMediaRequest{
+		Peer:       peer,
+		ReplyTo:    getReplyTo(elem.Thread()),
+		MultiMedia: items,
+	}
+	req.SetFlags()
+
+	if _, err := u.opts.Client.MessagesSendMultiMedia(ctx, req); err != nil {
+		return errors.Wrap(err, "send multi media")
+	}
+
+	return nil
+}
+
+func (u *Uploader) commitAlbumMedia(ctx context.Context, peer tg.InputPeerClass, media tg.InputMediaClass) (tg.InputMediaClass, error) {
+	res, err := u.opts.Client.MessagesUploadMedia(ctx, &tg.MessagesUploadMediaRequest{
+		Peer:  peer,
+		Media: media,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "upload media")
+	}
+	return convertToInputMedia(res)
+}
+
+func convertToInputMedia(m tg.MessageMediaClass) (tg.InputMediaClass, error) {
+	switch v := m.(type) {
+	case *tg.MessageMediaPhoto:
+		photo, ok := v.Photo.AsNotEmpty()
+		if !ok {
+			return nil, errors.Errorf("unexpected photo type %T", v.Photo)
+		}
+		return &tg.InputMediaPhoto{
+			ID:         photo.AsInput(),
+			TTLSeconds: v.TTLSeconds,
+		}, nil
+	case *tg.MessageMediaDocument:
+		document, ok := v.Document.AsNotEmpty()
+		if !ok {
+			return nil, errors.Errorf("unexpected document type %T", v.Document)
+		}
+		return &tg.InputMediaDocument{
+			ID:         document.AsInput(),
+			TTLSeconds: v.TTLSeconds,
+		}, nil
+	default:
+		return nil, errors.Errorf("unexpected media %T", m)
+	}
+}
+
+func (u *Uploader) buildInputMedia(ctx context.Context, elem Elem, media MediaDescriptor, ap *albumProgress) (tg.InputMediaClass, []tg.MessageEntityClass, error) {
+	entities := elem.CaptionEntities(media)
+
+	file, size, err := openSized(media.Path)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "open media file")
+	}
+	defer func() { _ = file.Close() }()
+
+	main := tduploader.NewUploader(u.opts.Client).
+		WithPartSize(MaxPartSize).
+		WithThreads(u.opts.Threads).
+		WithProgress(ap.newFileProgress())
+
+	inputFile, err := main.Upload(ctx, tduploader.NewUpload(filepath.Base(media.Path), file, size))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "upload media")
+	}
+
+	switch media.Type {
+	case MediaTypePhoto:
+		m := &tg.InputMediaUploadedPhoto{File: inputFile}
+		m.SetFlags()
+		return m, entities, nil
+	case MediaTypeVideo, MediaTypeDocument:
+		doc := &tg.InputMediaUploadedDocument{
+			NosoundVideo: false,
+			File:         inputFile,
+			MimeType:     media.Mime,
+			Attributes:   buildDocumentAttributes(media),
+		}
+
+		if media.Thumb != "" {
+			thumb, thumbSize, err := openSized(media.Thumb)
+			if err == nil {
+				defer func() { _ = thumb.Close() }()
+				if thumbFile, upErr := tduploader.NewUploader(u.opts.Client).
+					WithPartSize(MaxPartSize).
+					WithThreads(u.opts.Threads).
+					Upload(ctx, tduploader.NewUpload(filepath.Base(media.Thumb), thumb, thumbSize)); upErr == nil {
+					doc.Thumb = thumbFile
+				}
+			}
+		}
+
+		doc.SetFlags()
+		return doc, entities, nil
+	default:
+		return nil, nil, errors.Errorf("unsupported media type: %s", media.Type)
+	}
+}
+
+func buildDocumentAttributes(media MediaDescriptor) []tg.DocumentAttributeClass {
+	attrs := []tg.DocumentAttributeClass{
+		&tg.DocumentAttributeFilename{
+			FileName: filepath.Base(media.Path),
+		},
+	}
+
+	if media.Type == MediaTypeVideo {
+		v := &tg.DocumentAttributeVideo{
+			RoundMessage:      false,
+			SupportsStreaming: media.Streaming,
+			Nosound:           false,
+			W:                 media.Width,
+			H:                 media.Height,
+			Duration:          float64(media.Duration),
+		}
+		v.SetFlags()
+		attrs = append(attrs, v)
+	}
+
+	return attrs
+}
+
+func openSized(path string) (*os.File, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, 0, err
+	}
+
+	return f, stat.Size(), nil
+}
+
+type albumProgress struct {
+	elem     Elem
+	total    int64
+	uploaded atomic.Int64
+	process  Progress
+}
+
+func newAlbumProgress(elem Elem, process Progress) *albumProgress {
+	return &albumProgress{
+		elem:    elem,
+		total:   elem.TotalSize(),
+		process: process,
+	}
+}
+
+func (a *albumProgress) newFileProgress() *fileProgress {
+	return &fileProgress{album: a}
+}
+
+type fileProgress struct {
+	album *albumProgress
+	last  int64
+}
+
+func (p *fileProgress) Chunk(_ context.Context, state tduploader.ProgressState) error {
+	delta := state.Uploaded - p.last
+	p.last = state.Uploaded
+
+	total := p.album.uploaded.Add(delta)
+	p.album.process.OnUpload(p.album.elem, ProgressState{
+		Uploaded: total,
+		Total:    p.album.total,
+	})
+	return nil
+}
+
+func getReplyTo(msgID int) tg.InputReplyToClass {
+	if msgID == 0 {
+		return nil
+	}
+	reply := &tg.InputReplyToMessage{ReplyToMsgID: msgID}
+	reply.SetFlags()
+	return reply
 }

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/net v0.55.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 )
 
@@ -103,7 +104,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect


### PR DESCRIPTION
Adds streamable video uploads and Telegram grouped-media (albums) to the upload command, without regressing document uploads or single-file speed.

- --video: promote video/* files to streamable inline media, extracting duration, width, height and generating (or reusing a sidecar) thumbnail via ffprobe/ffmpeg. Metadata and thumbs are cached under .cache/ keyed by the source SHA-256.
- --detect-video: extension-based promotion for mp4/m4v/mov.
- --album: group items whose base name matches <model>_<YYYY-MM-DD>_<HH-MM-SS> into Telegram grouped media, chunked in batches of up to 10 via messages.sendMultiMedia.

Album pipeline: files within an album upload in parallel, each item is committed via messages.uploadMedia (converting InputMediaUploaded* to server-referenced InputMedia*), then messages.sendMultiMedia posts the group. The Uploader progress is shared across concurrent file uploads through an atomic accumulator so the bar reflects the album total instead of resetting per file.

Also fixes two latent bugs uncovered while wiring this up:
- getReplyTo returned a typed-nil *InputReplyToMessage which, when assigned to the InputReplyToClass interface field, produced a non-nil interface with a nil value. That set the reply flag on SendMultiMedia requests without a valid payload, and the server silently accepted the upload without delivering the album.
- Uploader.Upload swallowed any non-cancel error from u.upload, so failed sends showed as "done!" in the progress bar. Non-cancel errors now propagate to OnDone and mark the tracker as errored.

README documents the new flags, the album naming convention, the ffprobe/ffmpeg requirement and the cache layout.