### PR TITLE
fix(dl): prevent concurrent map read/write race

### DIFF
--- a/app/dl/iter.go
+++ b/app/dl/iter.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -335,7 +336,7 @@ func (i *iter) Finished() map[int]struct{} {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	return i.finished
+	return maps.Clone(i.finished)
 }
 
 func (i *iter) Fingerprint() string {


### PR DESCRIPTION

Fixes #1327

`iter.Finished()` returned the live map under the lock, but the lock was
released before `saveProgress` consumed it via `json.Marshal`. Downloader
goroutines still calling `Finish()` could concurrently write to the same
map, causing a Go runtime fatal error.

Fix: return `maps.Clone(i.finished)` under the lock so `saveProgress`
operates on a copy.
