### PR TITLE
feat(forward): add --skip-same to skip duplicate files

### DIFF
--- a/app/forward/forward.go
+++ b/app/forward/forward.go
@@ -15,10 +15,12 @@ import (
 	pw "github.com/jedib0t/go-pretty/v6/progress"
 	"github.com/spf13/viper"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"github.com/iyear/tdl/app/internal/tctx"
 	"github.com/iyear/tdl/core/dcpool"
 	"github.com/iyear/tdl/core/forwarder"
+	"github.com/iyear/tdl/core/logctx"
 	"github.com/iyear/tdl/core/storage"
 	"github.com/iyear/tdl/core/tclient"
 	"github.com/iyear/tdl/core/util/tutil"
@@ -29,14 +31,15 @@ import (
 )
 
 type Options struct {
-	From   []string
-	To     string
-	Edit   string
-	Mode   forwarder.Mode
-	Silent bool
-	DryRun bool
-	Single bool
-	Desc   bool
+	From     []string
+	To       string
+	Edit     string
+	Mode     forwarder.Mode
+	Silent   bool
+	DryRun   bool
+	Single   bool
+	Desc     bool
+	SkipSame bool
 }
 
 func Run(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts Options) (rerr error) {
@@ -84,28 +87,38 @@ func Run(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts Opti
 		prog.EnablePS(ctx, fwProgress)
 	}
 
+	go fwProgress.Render()
+	defer prog.Wait(ctx, fwProgress)
+
+	it := newIter(iterOptions{
+		manager:  manager,
+		pool:     pool,
+		to:       to,
+		edit:     edit,
+		dialogs:  dialogs,
+		mode:     opts.Mode,
+		silent:   opts.Silent,
+		dryRun:   opts.DryRun,
+		grouped:  !opts.Single,
+		delay:    viper.GetDuration(consts.FlagDelay),
+		skipSame: opts.SkipSame,
+	})
+
 	fw := forwarder.New(forwarder.Options{
-		Pool: pool,
-		Iter: newIter(iterOptions{
-			manager: manager,
-			pool:    pool,
-			to:      to,
-			edit:    edit,
-			dialogs: dialogs,
-			mode:    opts.Mode,
-			silent:  opts.Silent,
-			dryRun:  opts.DryRun,
-			grouped: !opts.Single,
-			delay:   viper.GetDuration(consts.FlagDelay),
-		}),
+		Pool:     pool,
+		Iter:     it,
 		Progress: newProgress(fwProgress),
 		Threads:  viper.GetInt(consts.FlagThreads),
 	})
 
-	go fwProgress.Render()
-	defer prog.Wait(ctx, fwProgress)
+	if err := fw.Forward(ctx); err != nil {
+		return err
+	}
 
-	return fw.Forward(ctx)
+	if n := it.Skipped(); n > 0 {
+		logctx.From(ctx).Info("skipped duplicated messages", zap.Int64("count", n))
+	}
+	return nil
 }
 
 func collectDialogs(ctx context.Context, input []string, desc bool) ([]*tmessage.Dialog, error) {

--- a/app/forward/iter.go
+++ b/app/forward/iter.go
@@ -175,7 +175,13 @@ func (i *iter) Next(ctx context.Context) bool {
 		}
 
 		// skip messages with the same file which have been forwarded
-		// in this run to the same destination
+		// in this run to the same destination.
+		//
+		// albums are deduplicated as a whole by their primary message media:
+		// children are not individually fingerprinted because an album is
+		// always sent as one unit, and skipping it entirely on any child match
+		// would drop unique files. dedup also applies to dry-run, so that the
+		// preview matches what a real run would send.
 		if i.opts.skipSame {
 			if key, ok := mediaKey(msg); ok {
 				k := mediaDestKey(to.ID(), thread, key)

--- a/app/forward/iter.go
+++ b/app/forward/iter.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -12,29 +13,36 @@ import (
 	"github.com/gotd/td/telegram/peers"
 	"github.com/gotd/td/tg"
 	"github.com/mitchellh/mapstructure"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
 
 	"github.com/iyear/tdl/core/dcpool"
 	"github.com/iyear/tdl/core/forwarder"
+	"github.com/iyear/tdl/core/logctx"
 	"github.com/iyear/tdl/core/util/tutil"
 	"github.com/iyear/tdl/pkg/texpr"
 	"github.com/iyear/tdl/pkg/tmessage"
 )
 
 type iterOptions struct {
-	manager *peers.Manager
-	pool    dcpool.Pool
-	to      *vm.Program
-	edit    *vm.Program
-	dialogs []*tmessage.Dialog
-	mode    forwarder.Mode
-	silent  bool
-	dryRun  bool
-	grouped bool
-	delay   time.Duration
+	manager  *peers.Manager
+	pool     dcpool.Pool
+	to       *vm.Program
+	edit     *vm.Program
+	dialogs  []*tmessage.Dialog
+	mode     forwarder.Mode
+	silent   bool
+	dryRun   bool
+	grouped  bool
+	delay    time.Duration
+	skipSame bool
 }
 
 type iter struct {
 	opts iterOptions
+
+	seen    map[string]struct{} // forwarded media keys, used by skip-same
+	skipped *atomic.Int64       // count of messages skipped by skip-same
 
 	i, j int
 	elem forwarder.Elem
@@ -75,6 +83,9 @@ func newIter(opts iterOptions) *iter {
 	return &iter{
 		opts: opts,
 
+		seen:    make(map[string]struct{}),
+		skipped: atomic.NewInt64(0),
+
 		i:    0,
 		j:    0,
 		elem: nil,
@@ -100,103 +111,127 @@ func (i *iter) Next(ctx context.Context) bool {
 		time.Sleep(i.opts.delay)
 	}
 
-	p, m := i.opts.dialogs[i.i].Peer, i.opts.dialogs[i.i].Messages[i.j]
-
-	if i.j++; i.j >= len(i.opts.dialogs[i.i].Messages) {
-		i.i++
-		i.j = 0
-	}
-
-	from, err := i.opts.manager.FromInputPeer(ctx, p)
-	if err != nil {
-		i.err = errors.Wrap(err, "get from peer")
-		return false
-	}
-
-	msg, err := tutil.GetSingleMessage(ctx, i.opts.pool.Default(ctx), from.InputPeer(), m)
-	if err != nil {
-		i.err = errors.Wrapf(err, "get message: %d", m)
-		return false
-	}
-
-	// message routing
-	result, err := texpr.Run(i.opts.to, exprEnv(from, msg))
-	if err != nil {
-		i.err = errors.Wrap(err, "message routing")
-		return false
-	}
-
-	var (
-		to     peers.Peer
-		thread int
-	)
-
-	switch r := result.(type) {
-	case string:
-		// pure chat, no reply to, which is a compatible with old version
-		// and a convenient way to send message to self
-		to, err = i.resolvePeer(ctx, r)
-	case map[string]interface{}:
-		// chat with reply to topic or message
-		var d dest
-
-		if err = mapstructure.WeakDecode(r, &d); err != nil {
-			i.err = errors.Wrapf(err, "decode dest: %v", result)
+	for {
+		// end of iteration
+		if i.i >= len(i.opts.dialogs) {
 			return false
 		}
 
-		to, err = i.resolvePeer(ctx, d.Peer)
-		thread = d.Thread
-	default:
-		i.err = errors.Errorf("message router must return string or dest: %T", result)
-		return false
-	}
+		p, m := i.opts.dialogs[i.i].Peer, i.opts.dialogs[i.i].Messages[i.j]
 
-	var modeOverride forwarder.Mode = -1 // default value is invalid
-	// edit message
-	if i.opts.edit != nil {
-		result, err = texpr.Run(i.opts.edit, exprEnv(from, msg))
+		if i.j++; i.j >= len(i.opts.dialogs[i.i].Messages) {
+			i.i++
+			i.j = 0
+		}
+
+		from, err := i.opts.manager.FromInputPeer(ctx, p)
 		if err != nil {
-			i.err = errors.Wrap(err, "edit message")
+			i.err = errors.Wrap(err, "get from peer")
 			return false
 		}
 
-		r, ok := result.(string)
-		if !ok {
-			i.err = errors.Errorf("edit must return string: %T", result)
+		msg, err := tutil.GetSingleMessage(ctx, i.opts.pool.Default(ctx), from.InputPeer(), m)
+		if err != nil {
+			i.err = errors.Wrapf(err, "get message: %d", m)
 			return false
 		}
 
-		eb := entity.Builder{}
-		if err = html.HTML(strings.NewReader(r), &eb, html.Options{
-			UserResolver:          nil,
-			DisableTelegramEscape: false,
-		}); err != nil {
-			i.err = errors.Wrap(err, "parse edited message")
+		// message routing
+		result, err := texpr.Run(i.opts.to, exprEnv(from, msg))
+		if err != nil {
+			i.err = errors.Wrap(err, "message routing")
 			return false
 		}
 
-		// modify message
-		msg.Message, msg.Entities = eb.Complete()
-		// direct mode can't modify message content, so we force it to be clone mode
-		modeOverride = forwarder.ModeClone
-	}
+		var (
+			to     peers.Peer
+			thread int
+		)
 
-	if err != nil {
-		i.err = errors.Wrapf(err, "resolve dest: %v", result)
-		return false
-	}
+		switch r := result.(type) {
+		case string:
+			// pure chat, no reply to, which is a compatible with old version
+			// and a convenient way to send message to self
+			to, err = i.resolvePeer(ctx, r)
+		case map[string]interface{}:
+			// chat with reply to topic or message
+			var d dest
 
-	i.elem = &iterElem{
-		from:         from,
-		msg:          msg,
-		to:           to,
-		thread:       thread,
-		modeOverride: modeOverride,
-		opts:         i.opts,
-	}
+			if err = mapstructure.WeakDecode(r, &d); err != nil {
+				i.err = errors.Wrapf(err, "decode dest: %v", result)
+				return false
+			}
 
-	return true
+			to, err = i.resolvePeer(ctx, d.Peer)
+			thread = d.Thread
+		default:
+			i.err = errors.Errorf("message router must return string or dest: %T", result)
+			return false
+		}
+
+		if err != nil {
+			i.err = errors.Wrapf(err, "resolve dest: %v", result)
+			return false
+		}
+
+		// skip messages with the same file which have been forwarded
+		// in this run to the same destination
+		if i.opts.skipSame {
+			if key, ok := mediaKey(msg); ok {
+				k := mediaDestKey(to.ID(), thread, key)
+				if _, dup := i.seen[k]; dup {
+					i.skipped.Inc()
+					logctx.From(ctx).Debug("skip duplicated message",
+						zap.Int64("from", from.ID()),
+						zap.Int64("to", to.ID()),
+						zap.Int("message", msg.ID))
+					continue
+				}
+				i.seen[k] = struct{}{}
+			}
+		}
+
+		var modeOverride forwarder.Mode = -1 // default value is invalid
+		// edit message
+		if i.opts.edit != nil {
+			result, err = texpr.Run(i.opts.edit, exprEnv(from, msg))
+			if err != nil {
+				i.err = errors.Wrap(err, "edit message")
+				return false
+			}
+
+			r, ok := result.(string)
+			if !ok {
+				i.err = errors.Errorf("edit must return string: %T", result)
+				return false
+			}
+
+			eb := entity.Builder{}
+			if err = html.HTML(strings.NewReader(r), &eb, html.Options{
+				UserResolver:          nil,
+				DisableTelegramEscape: false,
+			}); err != nil {
+				i.err = errors.Wrap(err, "parse edited message")
+				return false
+			}
+
+			// modify message
+			msg.Message, msg.Entities = eb.Complete()
+			// direct mode can't modify message content, so we force it to be clone mode
+			modeOverride = forwarder.ModeClone
+		}
+
+		i.elem = &iterElem{
+			from:         from,
+			msg:          msg,
+			to:           to,
+			thread:       thread,
+			modeOverride: modeOverride,
+			opts:         i.opts,
+		}
+
+		return true
+	}
 }
 
 func (i *iter) resolvePeer(ctx context.Context, peer string) (peers.Peer, error) {
@@ -205,6 +240,39 @@ func (i *iter) resolvePeer(ctx context.Context, peer string) (peers.Peer, error)
 	}
 
 	return tutil.GetInputPeer(ctx, i.opts.manager, peer)
+}
+
+// Skipped returns the number of messages skipped by the skip-same option.
+func (i *iter) Skipped() int64 {
+	return i.skipped.Load()
+}
+
+// mediaKey returns a stable identifier of the message media. It is used by
+// the skip-same option to detect duplicate files. The second return value is
+// false for messages without file media, which are never deduplicated.
+func mediaKey(msg *tg.Message) (string, bool) {
+	switch m := msg.Media.(type) {
+	case *tg.MessageMediaDocument:
+		doc, ok := m.Document.(*tg.Document)
+		if !ok {
+			return "", false
+		}
+		return fmt.Sprintf("doc:%d:%d", doc.ID, doc.Size), true
+	case *tg.MessageMediaPhoto:
+		photo, ok := m.Photo.(*tg.Photo)
+		if !ok {
+			return "", false
+		}
+		return fmt.Sprintf("photo:%d", photo.ID), true
+	default:
+		return "", false
+	}
+}
+
+// mediaDestKey scopes a media key to a destination peer id and thread, so that
+// forwarding the same file to different destinations is not skipped.
+func mediaDestKey(toID int64, thread int, key string) string {
+	return fmt.Sprintf("%d:%d:%s", toID, thread, key)
 }
 
 func (i *iter) Value() forwarder.Elem {

--- a/app/forward/mediakey_test.go
+++ b/app/forward/mediakey_test.go
@@ -1,0 +1,103 @@
+package forward
+
+import (
+	"testing"
+
+	"github.com/gotd/td/tg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaKeyDocument(t *testing.T) {
+	msg := &tg.Message{
+		ID: 1,
+		Media: &tg.MessageMediaDocument{
+			Document: &tg.Document{
+				ID:   42,
+				Size: 1024,
+			},
+		},
+	}
+
+	key, ok := mediaKey(msg)
+	require.True(t, ok)
+	assert.Equal(t, "doc:42:1024", key)
+
+	// same document id and size must produce the same key
+	same := &tg.Message{ID: 2, Media: msg.Media}
+	key2, ok := mediaKey(same)
+	require.True(t, ok)
+	assert.Equal(t, key, key2)
+
+	// different size must produce a different key
+	diffSize := &tg.Message{
+		ID: 3,
+		Media: &tg.MessageMediaDocument{
+			Document: &tg.Document{ID: 42, Size: 2048},
+		},
+	}
+	key3, ok := mediaKey(diffSize)
+	require.True(t, ok)
+	assert.NotEqual(t, key, key3)
+
+	// different id must produce a different key
+	diffID := &tg.Message{
+		ID: 4,
+		Media: &tg.MessageMediaDocument{
+			Document: &tg.Document{ID: 43, Size: 1024},
+		},
+	}
+	key4, ok := mediaKey(diffID)
+	require.True(t, ok)
+	assert.NotEqual(t, key, key4)
+}
+
+func TestMediaKeyPhoto(t *testing.T) {
+	photo := &tg.Photo{ID: 100}
+
+	msg := &tg.Message{
+		ID:    5,
+		Media: &tg.MessageMediaPhoto{Photo: photo},
+	}
+
+	key, ok := mediaKey(msg)
+	require.True(t, ok)
+	assert.Equal(t, "photo:100", key)
+
+	// same photo must produce the same key regardless of message id
+	same := &tg.Message{ID: 6, Media: &tg.MessageMediaPhoto{Photo: photo}}
+	key2, ok := mediaKey(same)
+	require.True(t, ok)
+	assert.Equal(t, key, key2)
+}
+
+func TestMediaKeyNoMedia(t *testing.T) {
+	cases := map[string]*tg.Message{
+		"no media":      {ID: 7},
+		"empty text":    {ID: 8, Message: ""},
+		"unknown media": {ID: 9, Media: &tg.MessageMediaGeo{Geo: &tg.GeoPointEmpty{}}},
+		"doc empty":     {ID: 10, Media: &tg.MessageMediaDocument{Document: &tg.DocumentEmpty{}}},
+		"photo empty":   {ID: 11, Media: &tg.MessageMediaPhoto{Photo: &tg.PhotoEmpty{}}},
+	}
+
+	for name, msg := range cases {
+		t.Run(name, func(t *testing.T) {
+			key, ok := mediaKey(msg)
+			assert.False(t, ok)
+			assert.Empty(t, key)
+		})
+	}
+}
+
+func TestMediaDestKey(t *testing.T) {
+	key := mediaDestKey(7, 0, "doc:42:1024")
+
+	// same destination and media -> same key
+	assert.Equal(t, key, mediaDestKey(7, 0, "doc:42:1024"))
+
+	// different thread -> different key
+	assert.NotEqual(t, key, mediaDestKey(7, 5, "doc:42:1024"))
+
+	// different destination -> different key
+	assert.NotEqual(t, key, mediaDestKey(8, 0, "doc:42:1024"))
+}

--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -36,6 +36,7 @@ func NewForward() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "do not actually send messages, just show how they would be sent")
 	cmd.Flags().BoolVar(&opts.Single, "single", false, "do not automatically detect and forward grouped messages")
 	cmd.Flags().BoolVar(&opts.Desc, "desc", false, "forward messages in reverse order for each input peer")
+	cmd.Flags().BoolVar(&opts.SkipSame, "skip-same", false, "skip messages with the same file that have been forwarded in this run")
 
 	return cmd
 }

--- a/docs/content/en/guide/forward.md
+++ b/docs/content/en/guide/forward.md
@@ -199,3 +199,13 @@ Forward messages in descending order for each source.
 {{< command >}}
 tdl forward --from tdl-export.json --desc
 {{< /command >}}
+
+## Skip Duplicates
+
+Skip messages whose file has already been forwarded in the current run to the same destination. Useful when the exported JSON contains duplicated media.
+
+{{< command >}}
+tdl forward --from tdl-export.json --skip-same
+{{< /command >}}
+
+Note: albums are deduplicated as a whole (based on their primary file), and messages without file media are never skipped.

--- a/docs/content/zh/guide/forward.md
+++ b/docs/content/zh/guide/forward.md
@@ -201,3 +201,13 @@ tdl forward --from tdl-export.json --single
 {{< command >}}
 tdl forward --from tdl-export.json --desc
 {{< /command >}}
+
+## 跳过重复
+
+跳过在本次运行中已经转发到相同目标的消息的重复文件。当导出的 JSON 中包含重复的媒体文件时非常有用。
+
+{{< command >}}
+tdl forward --from tdl-export.json --skip-same
+{{< /command >}}
+
+注意：相册会作为一个整体进行去重（基于其主文件），没有文件媒体的消息永远不会被跳过。


### PR DESCRIPTION
## Proposal

Fixes #1149.

When bulk forwarding from exported JSON files, the same media file may appear multiple times (overlapping exports, cross-posted documents, ...), and every occurrence gets forwarded again. This PR adds a `--skip-same` flag to `tdl forward`, mirroring the existing flag in `tdl dl`.

```bash
tdl forward --skip-same -f export.json
```

## Behavior

- A message is skipped if its media has **already been forwarded during this run** to the same destination peer/thread.
- Media identity is fingerprinted as:
  - document → `id + size`
  - photo → `id`
- Dedup is scoped per destination (`peer id + thread + media key`): routing the same file to two different chats is intentionally not affected.
- Messages without file media are never deduplicated.
- Skipped messages are logged at debug level and counted in a final summary log (`skipped duplicated messages count=N`).
- Dedup also applies to `--dry-run`, so the preview matches what a real run would send.
- Docs updated: "Skip Duplicates" section added to EN/ZH forward guide.

## Design notes

- Cross-run persistence was considered but intentionally not implemented: unlike `dl` (where the destination filesystem provides durable truth), forward would need local bookkeeping that can go stale (e.g., destination chat cleaned up), silently dropping legitimate re-forwards. Happy to discuss if maintainers prefer persistent KV-based dedup.
- Grouped messages (albums): dedup applies to the primary message media; album children are not individually fingerprinted (same as upstream grouped handling).

## Verification

- [x] `go build`, `go vet`, `gofmt`: clean
- [x] `go test -race ./app/forward/...`: green (new unit tests for media fingerprinting)
- [x] `golangci-lint run app/forward/... cmd/...`: 0 issues
- [x] `tdl forward --help` shows the new flag
- [x] Docs updated (EN + ZH guide)
