### PR TITLE
Feat/auto update

### DIFF
--- a/app/update/asset.go
+++ b/app/update/asset.go
@@ -61,7 +61,8 @@ func assetName(goos, goarch, goarm string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	archn, ok := archName(goarch, goarm)
+
+	arch, ok := archName(goarch, goarm)
 	if !ok {
 		return "", false
 	}
@@ -70,7 +71,8 @@ func assetName(goos, goarch, goarm string) (string, bool) {
 	if goos == osWindows {
 		ext = ".zip"
 	}
-	return fmt.Sprintf("%s_%s_%s%s", repoName, osn, archn, ext), true
+
+	return fmt.Sprintf("%s_%s_%s%s", repoName, osn, arch, ext), true
 }
 
 // binaryName returns the executable file name inside the release archive.

--- a/app/update/asset.go
+++ b/app/update/asset.go
@@ -1,0 +1,120 @@
+package update
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	repoOwner = "iyear"
+	repoName  = "tdl"
+
+	checksumAssetName = repoName + "_checksums.txt"
+
+	osWindows = "windows"
+	osLinux   = "linux"
+	osDarwin  = "darwin"
+)
+
+// goosName maps runtime.GOOS to the OS part of the release asset name,
+// following the goreleaser naming scheme (see .goreleaser.yaml).
+func goosName(goos string) (string, bool) {
+	switch goos {
+	case osLinux:
+		return "Linux", true
+	case osDarwin:
+		return "MacOS", true
+	case osWindows:
+		return "Windows", true
+	default:
+		return "", false
+	}
+}
+
+// archName maps GOARCH (and GOARM for arm builds) to the arch part of the
+// release asset name.
+func archName(goarch, goarm string) (string, bool) {
+	switch goarch {
+	case "386":
+		return "32bit", true
+	case "amd64":
+		return "64bit", true
+	case "arm":
+		switch goarm {
+		case "5", "6", "7":
+			return "armv" + goarm, true
+		default:
+			return "", false
+		}
+	case "arm64", "riscv64", "loong64":
+		return goarch, true
+	default:
+		return "", false
+	}
+}
+
+// assetName returns the archive asset filename for the given platform,
+// e.g. tdl_Linux_64bit.tar.gz or tdl_Windows_64bit.zip. The second return
+// value is false if the platform has no release assets.
+func assetName(goos, goarch, goarm string) (string, bool) {
+	osn, ok := goosName(goos)
+	if !ok {
+		return "", false
+	}
+	archn, ok := archName(goarch, goarm)
+	if !ok {
+		return "", false
+	}
+
+	ext := ".tar.gz"
+	if goos == osWindows {
+		ext = ".zip"
+	}
+	return fmt.Sprintf("%s_%s_%s%s", repoName, osn, archn, ext), true
+}
+
+// binaryName returns the executable file name inside the release archive.
+func binaryName(goos string) string {
+	if goos == osWindows {
+		return repoName + ".exe"
+	}
+	return repoName
+}
+
+// parseChecksums parses a goreleaser checksums.txt file
+// ("sha256sum" format: "<hex>  <filename>") into a map keyed by filename.
+// Lines whose digest is not a valid sha256 hex digest are ignored.
+func parseChecksums(content string) map[string]string {
+	sums := make(map[string]string)
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 || !isSHA256Hex(parts[0]) {
+			continue
+		}
+		name := strings.TrimPrefix(parts[1], "*")
+		sums[name] = strings.ToLower(parts[0])
+	}
+	return sums
+}
+
+// isSHA256Hex reports whether s is a 64-character lowercase/uppercase hex string.
+func isSHA256Hex(s string) bool {
+	if len(s) != sha256Len {
+		return false
+	}
+	for _, c := range s {
+		isDigit := c >= '0' && c <= '9'
+		isLower := c >= 'a' && c <= 'f'
+		isUpper := c >= 'A' && c <= 'F'
+		if !isDigit && !isLower && !isUpper {
+			return false
+		}
+	}
+	return true
+}
+
+const sha256Len = 64

--- a/app/update/update.go
+++ b/app/update/update.go
@@ -22,10 +22,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/go-faster/errors"
 	"github.com/google/go-github/v62/github"
-	"github.com/iyear/tdl/core/util/netutil"
 	"github.com/spf13/viper"
 	"golang.org/x/net/proxy"
 
+	"github.com/iyear/tdl/core/util/netutil"
 	"github.com/iyear/tdl/pkg/consts"
 )
 

--- a/app/update/update.go
+++ b/app/update/update.go
@@ -22,13 +22,16 @@ import (
 	"github.com/fatih/color"
 	"github.com/go-faster/errors"
 	"github.com/google/go-github/v62/github"
+	"github.com/iyear/tdl/core/util/netutil"
+	"github.com/spf13/viper"
+	"golang.org/x/net/proxy"
 
 	"github.com/iyear/tdl/pkg/consts"
 )
 
 type Options struct {
 	Yes    bool
-	Check  bool   // report availability without downloading anything
+	DryRun bool   // report availability without downloading anything
 	Target string // install a specific release tag instead of the latest (e.g. v0.20.4)
 	Force  bool   // reinstall even when up to date; also allows downgrades
 }
@@ -53,46 +56,54 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 		color.Yellow("--yes is set, updating anyway...")
 	}
 
-	release, err := fetchRelease(ctx, opts.Target)
+	dialer, err := netutil.NewProxy(viper.GetString(consts.FlagProxy))
+	if err != nil {
+		dialer = proxy.Direct
+	}
+
+	release, err := fetchRelease(ctx, opts.Target, dialer)
 	if err != nil {
 		return errors.Wrap(err, "fetch release")
 	}
 
-	latest := release.GetTagName()
-	fmt.Printf("Current version: %s\n", consts.Version)
+	tag := release.GetTagName()
+
+	fmt.Printf("%s: %s\n", color.BlueString("Current version"), color.CyanString(consts.Version))
 	if opts.Target != "" {
-		fmt.Printf("Target version:  %s\n", latest)
+		fmt.Printf("%s:  %s\n", color.BlueString("Target version"), color.CyanString(tag))
 	} else {
-		fmt.Printf("Latest version:  %s\n", latest)
+		fmt.Printf("%s:  %s\n", color.BlueString("Latest version"), color.CyanString(tag))
 	}
 
-	switch needsUpdate(consts.Version, latest) {
+	switch needsUpdate(consts.Version, tag) {
 	case updateNo:
 		if !opts.Force {
 			color.Green("You are already using the latest version.")
 			return nil
 		}
-		color.Yellow("--force is set, reinstalling %s.", latest)
+		color.Yellow("--force is set, reinstalling %s.", tag)
 	case updateUnknown:
-		color.Yellow("Unrecognized current version (%s), will update to %s.", consts.Version, latest)
+		color.Yellow("Unrecognized current version (%s), will update to %s.", consts.Version, tag)
 	default:
 		// updateYes: proceed with the update below.
 	}
 
-	if opts.Check {
-		color.Green("An update to %s is available.", latest)
+	if opts.DryRun {
+		color.Green("An update to %s is available.", tag)
 		return nil
 	}
 
 	if !opts.Yes {
 		ok := false
+
 		if err = survey.AskOne(&survey.Confirm{
-			Message: fmt.Sprintf("Update to %s?", latest),
+			Message: fmt.Sprintf("Update to %s?", tag),
 		}, &ok); err != nil {
 			return errors.Wrap(err, "confirm (use --yes to skip the prompt)")
 		}
+
 		if !ok {
-			fmt.Println("Aborted.")
+			color.Red("Aborted.")
 			return nil
 		}
 	}
@@ -100,7 +111,7 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 	goarm := goARM()
 	name, ok := assetName(runtime.GOOS, runtime.GOARCH, goarm)
 	if !ok {
-		return fmt.Errorf("no release assets for platform %s/%s/%s", runtime.GOOS, runtime.GOARCH, goarm)
+		return errors.Errorf("no release assets for platform %s/%s/%s", runtime.GOOS, runtime.GOARCH, goarm)
 	}
 
 	asset, err := findAsset(release, name)
@@ -119,13 +130,13 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 	defer func() { rerr = multiErr(rerr, os.RemoveAll(tmp)) }()
 
 	color.Cyan("Downloading %s...", asset.GetName())
-	archivePath, _, err := download(ctx, asset.GetBrowserDownloadURL(), filepath.Join(tmp, name))
+	archivePath, _, err := download(ctx, asset.GetBrowserDownloadURL(), filepath.Join(tmp, name), dialer)
 	if err != nil {
 		return errors.Wrap(err, "download archive")
 	}
 
 	color.Cyan("Verifying checksum...")
-	sumsPath, _, err := download(ctx, sumsAsset.GetBrowserDownloadURL(), filepath.Join(tmp, checksumAssetName))
+	sumsPath, _, err := download(ctx, sumsAsset.GetBrowserDownloadURL(), filepath.Join(tmp, checksumAssetName), dialer)
 	if err != nil {
 		return errors.Wrap(err, "download checksums")
 	}
@@ -148,7 +159,7 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 		return errors.Wrap(err, "replace binary")
 	}
 
-	color.Green("Successfully updated to %s. Enjoy!", latest)
+	color.Green("Successfully updated to %s. Enjoy!", tag)
 	return nil
 }
 
@@ -169,25 +180,39 @@ func needsUpdate(current, latest string) updateState {
 	if err != nil {
 		return updateUnknown
 	}
+
 	lat, err := semver.NewVersion(strings.TrimPrefix(latest, "v"))
 	if err != nil {
 		return updateUnknown
 	}
+
 	if cur.Compare(lat) >= 0 {
 		return updateNo
 	}
+
 	return updateYes
 }
 
 // fetchRelease returns the latest release, or the release tagged target if
 // target is not empty (e.g. "v0.20.4").
-func fetchRelease(ctx context.Context, target string) (*github.RepositoryRelease, error) {
-	client := github.NewClient(&http.Client{Timeout: 30 * time.Second})
+func fetchRelease(ctx context.Context, target string, dialer proxy.ContextDialer) (*github.RepositoryRelease, error) {
+	client := github.NewClient(&http.Client{
+		Transport: &http.Transport{
+			DialContext: dialer.DialContext,
+		},
+		Timeout: 30 * time.Second,
+	})
+
+	// Use GITHUB_TOKEN if set, to avoid hitting the unauthenticated rate limit.
+	if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken != "" {
+		client = client.WithAuthToken(ghToken)
+	}
 
 	var (
 		release *github.RepositoryRelease
 		err     error
 	)
+
 	if target == "" {
 		release, _, err = client.Repositories.GetLatestRelease(ctx, repoOwner, repoName)
 	} else {
@@ -199,9 +224,11 @@ func fetchRelease(ctx context.Context, target string) (*github.RepositoryRelease
 	if err != nil {
 		return nil, errors.Wrap(err, "github api")
 	}
+
 	if release == nil || release.GetTagName() == "" {
 		return nil, fmt.Errorf("release not found")
 	}
+
 	return release, nil
 }
 
@@ -230,13 +257,18 @@ func goARM() string {
 	return "7"
 }
 
-func download(ctx context.Context, url, path string) (string, int64, error) {
+func download(ctx context.Context, url, path string, dialer proxy.ContextDialer) (string, int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", 0, errors.Wrap(err, "create request")
 	}
 
-	resp, err := (&http.Client{Timeout: 10 * time.Minute}).Do(req)
+	resp, err := (&http.Client{
+		Transport: &http.Transport{
+			DialContext: dialer.DialContext,
+		},
+		Timeout: 10 * time.Minute,
+	}).Do(req)
 	if err != nil {
 		return "", 0, errors.Wrap(err, "do request")
 	}
@@ -250,14 +282,13 @@ func download(ctx context.Context, url, path string) (string, int64, error) {
 	if err != nil {
 		return "", 0, errors.Wrap(err, "create file")
 	}
+	defer func() { _ = f.Close() }()
+
 	size, err := io.Copy(f, resp.Body)
 	if err != nil {
-		_ = f.Close()
 		return "", 0, errors.Wrap(err, "save file")
 	}
-	if err = f.Close(); err != nil {
-		return "", 0, errors.Wrap(err, "close file")
-	}
+
 	return path, size, nil
 }
 

--- a/app/update/update.go
+++ b/app/update/update.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"atomicgo.dev/isadmin"
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
@@ -40,6 +41,11 @@ type Options struct {
 // matching archive, verifies its checksum and atomically replaces the current
 // binary.
 func Run(ctx context.Context, opts Options) (rerr error) {
+	if !isadmin.Check() {
+		color.Red("Must be run as administrator/root")
+		return nil
+	}
+
 	exe, err := os.Executable()
 	if err != nil {
 		return errors.Wrap(err, "get executable path")
@@ -49,11 +55,8 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 	}
 
 	if strings.Contains(filepath.ToSlash(exe), "/Cellar/") {
-		color.Yellow("tdl seems to be installed via Homebrew, please update it with 'brew upgrade tdl' instead.")
-		if !opts.Yes {
-			return nil
-		}
-		color.Yellow("--yes is set, updating anyway...")
+		color.Yellow("tdl seems to be installed via Homebrew, please update it with brew instead.")
+		return nil
 	}
 
 	dialer, err := netutil.NewProxy(viper.GetString(consts.FlagProxy))

--- a/app/update/update.go
+++ b/app/update/update.go
@@ -27,7 +27,10 @@ import (
 )
 
 type Options struct {
-	Yes bool
+	Yes    bool
+	Check  bool   // report availability without downloading anything
+	Target string // install a specific release tag instead of the latest (e.g. v0.20.4)
+	Force  bool   // reinstall even when up to date; also allows downgrades
 }
 
 // Run performs a self-update: checks the latest GitHub release, downloads the
@@ -50,22 +53,35 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 		color.Yellow("--yes is set, updating anyway...")
 	}
 
-	release, err := fetchLatestRelease(ctx)
+	release, err := fetchRelease(ctx, opts.Target)
 	if err != nil {
-		return errors.Wrap(err, "fetch latest release")
+		return errors.Wrap(err, "fetch release")
 	}
 
 	latest := release.GetTagName()
 	fmt.Printf("Current version: %s\n", consts.Version)
-	fmt.Printf("Latest version:  %s\n", latest)
+	if opts.Target != "" {
+		fmt.Printf("Target version:  %s\n", latest)
+	} else {
+		fmt.Printf("Latest version:  %s\n", latest)
+	}
 
 	switch needsUpdate(consts.Version, latest) {
 	case updateNo:
-		color.Green("You are already using the latest version.")
-		return nil
+		if !opts.Force {
+			color.Green("You are already using the latest version.")
+			return nil
+		}
+		color.Yellow("--force is set, reinstalling %s.", latest)
 	case updateUnknown:
 		color.Yellow("Unrecognized current version (%s), will update to %s.", consts.Version, latest)
 	default:
+		// updateYes: proceed with the update below.
+	}
+
+	if opts.Check {
+		color.Green("An update to %s is available.", latest)
+		return nil
 	}
 
 	if !opts.Yes {
@@ -164,14 +180,28 @@ func needsUpdate(current, latest string) updateState {
 	return updateYes
 }
 
-func fetchLatestRelease(ctx context.Context) (*github.RepositoryRelease, error) {
+// fetchRelease returns the latest release, or the release tagged target if
+// target is not empty (e.g. "v0.20.4").
+func fetchRelease(ctx context.Context, target string) (*github.RepositoryRelease, error) {
 	client := github.NewClient(&http.Client{Timeout: 30 * time.Second})
-	release, _, err := client.Repositories.GetLatestRelease(ctx, repoOwner, repoName)
+
+	var (
+		release *github.RepositoryRelease
+		err     error
+	)
+	if target == "" {
+		release, _, err = client.Repositories.GetLatestRelease(ctx, repoOwner, repoName)
+	} else {
+		if _, err = semver.NewVersion(strings.TrimPrefix(target, "v")); err != nil {
+			return nil, fmt.Errorf("invalid target version %q: %w", target, err)
+		}
+		release, _, err = client.Repositories.GetReleaseByTag(ctx, repoOwner, repoName, target)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "github api")
 	}
 	if release == nil || release.GetTagName() == "" {
-		return nil, fmt.Errorf("latest release not found")
+		return nil, fmt.Errorf("release not found")
 	}
 	return release, nil
 }
@@ -359,6 +389,9 @@ func replaceBinary(target, src string) error {
 	staged := filepath.Join(dir, "."+filepath.Base(target)+".update")
 
 	if err := copyFile(src, staged, 0o755); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return errors.Wrapf(err, "stage new binary in %s: permission denied (check directory ownership, or use your package manager)", dir)
+		}
 		return errors.Wrap(err, "stage new binary")
 	}
 

--- a/app/update/update.go
+++ b/app/update/update.go
@@ -395,9 +395,12 @@ func replaceBinary(target, src string) error {
 	}
 
 	if runtime.GOOS == osWindows {
+		// a running .exe cannot be deleted or renamed over, but it can be
+		// renamed away: move the old binary to "<name>.old", put the new one
+		// in place, and roll back from the backup if anything fails.
 		bak := target + ".old"
 		_ = os.Remove(bak)
-		if err := os.Rename(target, bak); err != nil && !os.IsNotExist(err) {
+		if err := os.Rename(target, bak); err != nil && !errors.Is(err, os.ErrNotExist) {
 			_ = os.Remove(staged)
 			return errors.Wrap(err, "backup old binary")
 		}
@@ -405,6 +408,7 @@ func replaceBinary(target, src string) error {
 			_ = os.Rename(bak, target) // rollback
 			return errors.Wrap(err, "replace binary")
 		}
+		_ = os.Remove(bak) // best-effort cleanup of the backup
 		return nil
 	}
 

--- a/app/update/update.go
+++ b/app/update/update.go
@@ -119,7 +119,7 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 	defer func() { rerr = multiErr(rerr, os.RemoveAll(tmp)) }()
 
 	color.Cyan("Downloading %s...", asset.GetName())
-	archivePath, size, err := download(ctx, asset.GetBrowserDownloadURL(), filepath.Join(tmp, name))
+	archivePath, _, err := download(ctx, asset.GetBrowserDownloadURL(), filepath.Join(tmp, name))
 	if err != nil {
 		return errors.Wrap(err, "download archive")
 	}
@@ -142,7 +142,6 @@ func Run(ctx context.Context, opts Options) (rerr error) {
 	if err != nil {
 		return errors.Wrap(err, "extract binary")
 	}
-	_ = size
 
 	color.Cyan("Replacing %s...", exe)
 	if err = replaceBinary(exe, binPath); err != nil {

--- a/app/update/update.go
+++ b/app/update/update.go
@@ -1,0 +1,416 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/Masterminds/semver/v3"
+	"github.com/fatih/color"
+	"github.com/go-faster/errors"
+	"github.com/google/go-github/v62/github"
+
+	"github.com/iyear/tdl/pkg/consts"
+)
+
+type Options struct {
+	Yes bool
+}
+
+// Run performs a self-update: checks the latest GitHub release, downloads the
+// matching archive, verifies its checksum and atomically replaces the current
+// binary.
+func Run(ctx context.Context, opts Options) (rerr error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return errors.Wrap(err, "get executable path")
+	}
+	if exe, err = filepath.EvalSymlinks(exe); err != nil {
+		return errors.Wrap(err, "resolve executable path")
+	}
+
+	if strings.Contains(filepath.ToSlash(exe), "/Cellar/") {
+		color.Yellow("tdl seems to be installed via Homebrew, please update it with 'brew upgrade tdl' instead.")
+		if !opts.Yes {
+			return nil
+		}
+		color.Yellow("--yes is set, updating anyway...")
+	}
+
+	release, err := fetchLatestRelease(ctx)
+	if err != nil {
+		return errors.Wrap(err, "fetch latest release")
+	}
+
+	latest := release.GetTagName()
+	fmt.Printf("Current version: %s\n", consts.Version)
+	fmt.Printf("Latest version:  %s\n", latest)
+
+	switch needsUpdate(consts.Version, latest) {
+	case updateNo:
+		color.Green("You are already using the latest version.")
+		return nil
+	case updateUnknown:
+		color.Yellow("Unrecognized current version (%s), will update to %s.", consts.Version, latest)
+	default:
+	}
+
+	if !opts.Yes {
+		ok := false
+		if err = survey.AskOne(&survey.Confirm{
+			Message: fmt.Sprintf("Update to %s?", latest),
+		}, &ok); err != nil {
+			return errors.Wrap(err, "confirm (use --yes to skip the prompt)")
+		}
+		if !ok {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	goarm := goARM()
+	name, ok := assetName(runtime.GOOS, runtime.GOARCH, goarm)
+	if !ok {
+		return fmt.Errorf("no release assets for platform %s/%s/%s", runtime.GOOS, runtime.GOARCH, goarm)
+	}
+
+	asset, err := findAsset(release, name)
+	if err != nil {
+		return err
+	}
+	sumsAsset, err := findAsset(release, checksumAssetName)
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.MkdirTemp("", "tdl-update-")
+	if err != nil {
+		return errors.Wrap(err, "create temp dir")
+	}
+	defer func() { rerr = multiErr(rerr, os.RemoveAll(tmp)) }()
+
+	color.Cyan("Downloading %s...", asset.GetName())
+	archivePath, size, err := download(ctx, asset.GetBrowserDownloadURL(), filepath.Join(tmp, name))
+	if err != nil {
+		return errors.Wrap(err, "download archive")
+	}
+
+	color.Cyan("Verifying checksum...")
+	sumsPath, _, err := download(ctx, sumsAsset.GetBrowserDownloadURL(), filepath.Join(tmp, checksumAssetName))
+	if err != nil {
+		return errors.Wrap(err, "download checksums")
+	}
+	sumsData, err := os.ReadFile(sumsPath)
+	if err != nil {
+		return errors.Wrap(err, "read checksums")
+	}
+	if err = verifyChecksum(sumsData, filepath.Base(archivePath), archivePath); err != nil {
+		return errors.Wrap(err, "verify checksum")
+	}
+
+	color.Cyan("Extracting %s...", name)
+	binPath, err := extractBinary(archivePath, binaryName(runtime.GOOS), tmp)
+	if err != nil {
+		return errors.Wrap(err, "extract binary")
+	}
+	_ = size
+
+	color.Cyan("Replacing %s...", exe)
+	if err = replaceBinary(exe, binPath); err != nil {
+		return errors.Wrap(err, "replace binary")
+	}
+
+	color.Green("Successfully updated to %s. Enjoy!", latest)
+	return nil
+}
+
+// updateState is the result of comparing the current version with the latest one.
+type updateState int
+
+const (
+	updateYes updateState = iota
+	updateNo
+	updateUnknown
+)
+
+// needsUpdate compares two version strings ("v1.2.3" or "1.2.3"). It returns
+// updateUnknown if the current version is not a parseable release version
+// (e.g. "dev"), so that dev builds can still self-update.
+func needsUpdate(current, latest string) updateState {
+	cur, err := semver.NewVersion(strings.TrimPrefix(current, "v"))
+	if err != nil {
+		return updateUnknown
+	}
+	lat, err := semver.NewVersion(strings.TrimPrefix(latest, "v"))
+	if err != nil {
+		return updateUnknown
+	}
+	if cur.Compare(lat) >= 0 {
+		return updateNo
+	}
+	return updateYes
+}
+
+func fetchLatestRelease(ctx context.Context) (*github.RepositoryRelease, error) {
+	client := github.NewClient(&http.Client{Timeout: 30 * time.Second})
+	release, _, err := client.Repositories.GetLatestRelease(ctx, repoOwner, repoName)
+	if err != nil {
+		return nil, errors.Wrap(err, "github api")
+	}
+	if release == nil || release.GetTagName() == "" {
+		return nil, fmt.Errorf("latest release not found")
+	}
+	return release, nil
+}
+
+func findAsset(release *github.RepositoryRelease, name string) (*github.ReleaseAsset, error) {
+	for _, a := range release.Assets {
+		if a.GetName() == name {
+			return a, nil
+		}
+	}
+	return nil, fmt.Errorf("asset %q not found in release %s", name, release.GetTagName())
+}
+
+// goARM returns the GOARM value used to build the binary ("7" as fallback),
+// or an empty string on non-arm platforms.
+func goARM() string {
+	if runtime.GOARCH != "arm" {
+		return ""
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "GOARM" && s.Value != "" {
+				return s.Value
+			}
+		}
+	}
+	return "7"
+}
+
+func download(ctx context.Context, url, path string) (string, int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", 0, errors.Wrap(err, "create request")
+	}
+
+	resp, err := (&http.Client{Timeout: 10 * time.Minute}).Do(req)
+	if err != nil {
+		return "", 0, errors.Wrap(err, "do request")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return "", 0, errors.Wrap(err, "create file")
+	}
+	size, err := io.Copy(f, resp.Body)
+	if err != nil {
+		_ = f.Close()
+		return "", 0, errors.Wrap(err, "save file")
+	}
+	if err = f.Close(); err != nil {
+		return "", 0, errors.Wrap(err, "close file")
+	}
+	return path, size, nil
+}
+
+func verifyChecksum(sumsContent []byte, name, path string) error {
+	expected, ok := parseChecksums(string(sumsContent))[name]
+	if !ok {
+		return fmt.Errorf("checksum for %q not found", name)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.Wrap(err, "open file")
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err = io.Copy(h, f); err != nil {
+		return errors.Wrap(err, "hash file")
+	}
+
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != expected {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expected, got)
+	}
+	return nil
+}
+
+// extractBinary extracts the executable from a .tar.gz or .zip archive into dir.
+func extractBinary(archivePath, binName, dir string) (string, error) {
+	dest := filepath.Join(dir, binName)
+
+	switch {
+	case strings.HasSuffix(archivePath, ".zip"):
+		if err := extractFromZip(archivePath, binName, dest); err != nil {
+			return "", err
+		}
+	case strings.HasSuffix(archivePath, ".tar.gz"):
+		if err := extractFromTarGz(archivePath, binName, dest); err != nil {
+			return "", err
+		}
+	default:
+		return "", fmt.Errorf("unsupported archive format: %s", archivePath)
+	}
+
+	// 0755: the binary must be executable for everyone, like the install script does.
+	if err := os.Chmod(dest, 0o755); err != nil {
+		return "", errors.Wrap(err, "chmod binary")
+	}
+	return dest, nil
+}
+
+func extractFromTarGz(archivePath, binName, dest string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return errors.Wrap(err, "open archive")
+	}
+	defer func() { _ = f.Close() }()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return errors.Wrap(err, "gzip reader")
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("%q not found in archive", binName)
+		}
+		if err != nil {
+			return errors.Wrap(err, "tar next")
+		}
+		if filepath.Base(hdr.Name) != binName || hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+		if err != nil {
+			return errors.Wrap(err, "create output file")
+		}
+		if _, err = io.Copy(out, tr); err != nil {
+			_ = out.Close()
+			return errors.Wrap(err, "copy binary")
+		}
+		return out.Close()
+	}
+}
+
+func extractFromZip(archivePath, binName, dest string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return errors.Wrap(err, "zip open reader")
+	}
+	defer func() { _ = r.Close() }()
+
+	for _, zf := range r.File {
+		if filepath.Base(zf.Name) != binName || zf.FileInfo().IsDir() {
+			continue
+		}
+		src, err := zf.Open()
+		if err != nil {
+			return errors.Wrap(err, "open zip entry")
+		}
+		out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+		if err != nil {
+			_ = src.Close()
+			return errors.Wrap(err, "create output file")
+		}
+		if _, err = io.Copy(out, src); err != nil {
+			_ = out.Close()
+			_ = src.Close()
+			return errors.Wrap(err, "copy binary")
+		}
+		if err = out.Close(); err != nil {
+			_ = src.Close()
+			return errors.Wrap(err, "close output file")
+		}
+		return src.Close()
+	}
+	return fmt.Errorf("%q not found in archive", binName)
+}
+
+// replaceBinary moves the new binary over the current executable. On unix it
+// is an atomic rename within the same filesystem; on windows the old binary
+// is kept as "<name>.old" until a successful replacement for rollback.
+func replaceBinary(target, src string) error {
+	dir := filepath.Dir(target)
+	staged := filepath.Join(dir, "."+filepath.Base(target)+".update")
+
+	if err := copyFile(src, staged, 0o755); err != nil {
+		return errors.Wrap(err, "stage new binary")
+	}
+
+	if runtime.GOOS == osWindows {
+		bak := target + ".old"
+		_ = os.Remove(bak)
+		if err := os.Rename(target, bak); err != nil && !os.IsNotExist(err) {
+			_ = os.Remove(staged)
+			return errors.Wrap(err, "backup old binary")
+		}
+		if err := os.Rename(staged, target); err != nil {
+			_ = os.Rename(bak, target) // rollback
+			return errors.Wrap(err, "replace binary")
+		}
+		return nil
+	}
+
+	if err := os.Rename(staged, target); err != nil {
+		_ = os.Remove(staged)
+		return errors.Wrap(err, "replace binary")
+	}
+	return nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return errors.Wrap(err, "open source")
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return errors.Wrap(err, "create destination")
+	}
+	if _, err = io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return errors.Wrap(err, "copy content")
+	}
+	if err = out.Sync(); err != nil {
+		_ = out.Close()
+		return errors.Wrap(err, "sync destination")
+	}
+	return out.Close()
+}
+
+func multiErr(a, b error) error {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return fmt.Errorf("%v; %v", a, b)
+}

--- a/app/update/update_test.go
+++ b/app/update/update_test.go
@@ -1,0 +1,131 @@
+package update
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// test constants to keep goconst happy
+const (
+	tLinux   = "linux"
+	tDarwin  = "darwin"
+	tWindows = "windows"
+	tAmd64   = "amd64"
+	tArm     = "arm"
+	tArm64   = "arm64"
+
+	vLatest = "v0.20.4"
+)
+
+func TestAssetName(t *testing.T) {
+	tests := []struct {
+		name   string
+		goos   string
+		goarch string
+		goarm  string
+		want   string
+		ok     bool
+	}{
+		{"linux amd64", tLinux, tAmd64, "", "tdl_Linux_64bit.tar.gz", true},
+		{"linux 386", tLinux, "386", "", "tdl_Linux_32bit.tar.gz", true},
+		{"linux arm64", tLinux, tArm64, "", "tdl_Linux_arm64.tar.gz", true},
+		{"linux riscv64", tLinux, "riscv64", "", "tdl_Linux_riscv64.tar.gz", true},
+		{"linux loong64", tLinux, "loong64", "", "tdl_Linux_loong64.tar.gz", true},
+		{"linux armv6", tLinux, tArm, "6", "tdl_Linux_armv6.tar.gz", true},
+		{"linux armv7", tLinux, tArm, "7", "tdl_Linux_armv7.tar.gz", true},
+		{"macos amd64", tDarwin, tAmd64, "", "tdl_MacOS_64bit.tar.gz", true},
+		{"macos arm64", tDarwin, tArm64, "", "tdl_MacOS_arm64.tar.gz", true},
+		{"windows amd64", tWindows, tAmd64, "", "tdl_Windows_64bit.zip", true},
+		{"windows armv5", tWindows, tArm, "5", "tdl_Windows_armv5.zip", true},
+		{"unsupported os", "freebsd", tAmd64, "", "", false},
+		{"unsupported arch", tLinux, "mips", "", "", false},
+		{"bad goarm", tLinux, tArm, "8", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := assetName(tt.goos, tt.goarch, tt.goarm)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestAssetNameAgainstRealRelease verifies that every platform built by
+// goreleaser produces an asset name that matches a real release asset list.
+func TestAssetNameAgainstRealRelease(t *testing.T) {
+	releaseAssets := map[string]bool{
+		"tdl_Linux_32bit.tar.gz": true, "tdl_Linux_64bit.tar.gz": true,
+		"tdl_Linux_arm64.tar.gz": true, "tdl_Linux_armv5.tar.gz": true,
+		"tdl_Linux_armv6.tar.gz": true, "tdl_Linux_armv7.tar.gz": true,
+		"tdl_Linux_loong64.tar.gz": true, "tdl_Linux_riscv64.tar.gz": true,
+		"tdl_MacOS_64bit.tar.gz": true, "tdl_MacOS_arm64.tar.gz": true,
+		"tdl_Windows_32bit.zip": true, "tdl_Windows_64bit.zip": true,
+		"tdl_Windows_arm64.zip": true, "tdl_Windows_armv5.zip": true,
+		"tdl_Windows_armv6.zip": true, "tdl_Windows_armv7.zip": true,
+	}
+
+	for _, goarch := range []string{"386", tAmd64, tArm64, "riscv64", "loong64"} {
+		got, ok := assetName(tLinux, goarch, "")
+		assert.True(t, ok)
+		assert.True(t, releaseAssets[got], "asset %s should exist in release", got)
+	}
+	for _, arm := range []string{"5", "6", "7"} {
+		got, ok := assetName(tLinux, tArm, arm)
+		assert.True(t, ok)
+		assert.True(t, releaseAssets[got], "asset %s should exist in release", got)
+	}
+}
+
+func TestBinaryName(t *testing.T) {
+	assert.Equal(t, "tdl.exe", binaryName("windows"))
+	assert.Equal(t, "tdl", binaryName(runtime.GOOS))
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, "tdl", binaryName(runtime.GOOS))
+	}
+}
+
+func TestParseChecksums(t *testing.T) {
+	content := `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  tdl_Linux_64bit.tar.gz
+1111111111111111111111111111111111111111111111111111111111111111 *tdl_Windows_64bit.zip
+
+invalid line
+2222222222222222222222222222222222222222222222222222222222222222 tdl_MacOS_arm64.tar.gz
+`
+	sums := parseChecksums(content)
+
+	assert.Len(t, sums, 3)
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", sums["tdl_Linux_64bit.tar.gz"])
+	// binary-mode marker "*" must be stripped
+	assert.Equal(t, "1111111111111111111111111111111111111111111111111111111111111111", sums["tdl_Windows_64bit.zip"])
+	assert.Equal(t, "2222222222222222222222222222222222222222222222222222222222222222", sums["tdl_MacOS_arm64.tar.gz"])
+
+	_, ok := sums["missing.tar.gz"]
+	assert.False(t, ok)
+}
+
+func TestNeedsUpdate(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    updateState
+	}{
+		{"older current", "v0.20.3", vLatest, updateYes},
+		{"same version", vLatest, vLatest, updateNo},
+		{"no v prefix", "0.20.4", vLatest, updateNo},
+		{"newer current", "v0.21.0", vLatest, updateNo},
+		{"minor bump", "v0.19.9", "v0.20.0", updateYes},
+		{"dev build", "dev", vLatest, updateUnknown},
+		{"empty current", "", vLatest, updateUnknown},
+		{"garbage current", "not-a-version", vLatest, updateUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, needsUpdate(tt.current, tt.latest))
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,7 +139,7 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(NewVersion(), NewLogin(), NewDownload(), NewForward(),
 		NewChat(), NewUpload(), NewBackup(), NewRecover(), NewMigrate(),
-		NewGen(), NewExtension(em))
+		NewGen(), NewUpdate(), NewExtension(em))
 
 	// append extension command to root
 	exts, _ := em.List(context.Background(), false)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/iyear/tdl/app/update"
+)
+
+func NewUpdate() *cobra.Command {
+	var opts update.Options
+
+	cmd := &cobra.Command{
+		Use:     "update",
+		Short:   "Update tdl to the latest version",
+		GroupID: groupTools.ID,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return update.Run(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "update without confirmation prompt")
+
+	return cmd
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -11,6 +11,7 @@ func NewUpdate() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "update",
+		Aliases: []string{"upgrade"},
 		Short:   "Update tdl to the latest version",
 		GroupID: groupTools.ID,
 		Long: `Update tdl in place by downloading a release from GitHub,
@@ -18,7 +19,7 @@ verifying its checksum and replacing the current binary.
 
 Examples:
   tdl update                     # install latest verified release
-  tdl update --check             # report availability only
+  tdl update --dry-run           # report availability only
   tdl update --version v0.20.4   # install an exact release
   tdl update --force             # reinstall / allow downgrade`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -27,9 +28,9 @@ Examples:
 	}
 
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "update without confirmation prompt")
-	cmd.Flags().BoolVar(&opts.Check, "check", false, "report whether an update is available without downloading")
-	cmd.Flags().StringVar(&opts.Target, "version", "", "install a specific release tag instead of the latest (e.g. v0.20.4)")
-	cmd.Flags().BoolVar(&opts.Force, "force", false, "reinstall even when up to date; also allows downgrades")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "report whether an update is available without downloading")
+	cmd.Flags().StringVarP(&opts.Target, "version", "v", "", "install a specific release tag instead of the latest (e.g. v0.20.4)")
+	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "reinstall even when up to date; also allows downgrades")
 
 	return cmd
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -13,12 +13,23 @@ func NewUpdate() *cobra.Command {
 		Use:     "update",
 		Short:   "Update tdl to the latest version",
 		GroupID: groupTools.ID,
+		Long: `Update tdl in place by downloading a release from GitHub,
+verifying its checksum and replacing the current binary.
+
+Examples:
+  tdl update                     # install latest verified release
+  tdl update --check             # report availability only
+  tdl update --version v0.20.4   # install an exact release
+  tdl update --force             # reinstall / allow downgrade`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return update.Run(cmd.Context(), opts)
 		},
 	}
 
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "update without confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Check, "check", false, "report whether an update is available without downloading")
+	cmd.Flags().StringVar(&opts.Target, "version", "", "install a specific release tag instead of the latest (e.g. v0.20.4)")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "reinstall even when up to date; also allows downgrades")
 
 	return cmd
 }

--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -62,7 +62,7 @@ curl -sSL https://docs.iyear.me/tdl/install.sh | sudo bash -s -- --version VERSI
 
 ### Update
 
-`tdl` can update itself to the latest release:
+`tdl` can update itself to the latest release with admin/root permission:
 
 {{< command >}}
 tdl update

--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -81,7 +81,7 @@ GITHUB_TOKEN=ghp_XXXX tdl update            # use GitHub token to avoid rate lim
 {{< /command >}}
 
 {{< hint info >}}
-If `tdl` was installed via Homebrew, please use `brew upgrade tdl` instead.
+If `tdl` was installed via package manager/docker, please use the package manager/docker to update `tdl`.
 {{< /hint >}}
 
 ## Package Managers

--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -273,3 +273,16 @@ Then build:
 go install github.com/iyear/tdl@latest
 tdl version
 {{< /command >}}
+
+## Update
+
+`tdl` can update itself to the latest release:
+
+{{< command >}}
+tdl update
+tdl version
+{{< /command >}}
+
+{{< hint info >}}
+Use `tdl update --yes` to skip the confirmation prompt (e.g. in scripts). The new binary's checksum is verified before replacing the old one. If `tdl` was installed via Homebrew, please use `brew upgrade tdl` instead.
+{{< /hint >}}

--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -283,6 +283,14 @@ tdl update
 tdl version
 {{< /command >}}
 
+Other options:
+
+{{< command >}}
+tdl update --check             # report availability only
+tdl update --version v0.20.4   # install an exact release
+tdl update --force             # reinstall / allow downgrade
+{{< /command >}}
+
 {{< hint info >}}
 Use `tdl update --yes` to skip the confirmation prompt (e.g. in scripts). The new binary's checksum is verified before replacing the old one. If `tdl` was installed via Homebrew, please use `brew upgrade tdl` instead.
 {{< /hint >}}

--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -286,11 +286,13 @@ tdl version
 Other options:
 
 {{< command >}}
-tdl update --check             # report availability only
-tdl update --version v0.20.4   # install an exact release
-tdl update --force             # reinstall / allow downgrade
+tdl update --proxy socks5://localhost:1080  # use proxy to fetch release
+tdl update --dry-run                        # report availability only
+tdl update --version(-v) v0.20.4            # install an exact release
+tdl update --force(-f)                      # reinstall / allow downgrade
+GITHUB_TOKEN=ghp_XXXX tdl update            # use GitHub token to avoid rate limit
 {{< /command >}}
 
 {{< hint info >}}
-Use `tdl update --yes` to skip the confirmation prompt (e.g. in scripts). The new binary's checksum is verified before replacing the old one. If `tdl` was installed via Homebrew, please use `brew upgrade tdl` instead.
+Use `tdl update --yes(-y)` to skip the confirmation prompt (e.g. in scripts). The new binary's checksum is verified before replacing the old one. If `tdl` was installed via Homebrew, please use `brew upgrade tdl` instead.
 {{< /hint >}}

--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -60,6 +60,30 @@ curl -sSL https://docs.iyear.me/tdl/install.sh | sudo bash -s -- --version VERSI
 {{< /tab >}}
 {{< /tabs >}}
 
+### Update
+
+`tdl` can update itself to the latest release:
+
+{{< command >}}
+tdl update
+tdl version
+{{< /command >}}
+
+Other options:
+
+{{< command >}}
+tdl update --proxy socks5://localhost:1080  # use proxy to fetch release
+tdl update --dry-run                        # report availability only
+tdl update --version(-v) v0.20.4            # install an exact release
+tdl update --force(-f)                      # reinstall / allow downgrade
+tdl update --yes(-y)                        # skip confirmation prompt
+GITHUB_TOKEN=ghp_XXXX tdl update            # use GitHub token to avoid rate limit
+{{< /command >}}
+
+{{< hint info >}}
+If `tdl` was installed via Homebrew, please use `brew upgrade tdl` instead.
+{{< /hint >}}
+
 ## Package Managers
 
 {{< tabs "package managers" >}}
@@ -273,27 +297,3 @@ Then build:
 go install github.com/iyear/tdl@latest
 tdl version
 {{< /command >}}
-
-## Update
-
-`tdl` can update itself to the latest release:
-
-{{< command >}}
-tdl update
-tdl version
-{{< /command >}}
-
-Other options:
-
-{{< command >}}
-tdl update --proxy socks5://localhost:1080  # use proxy to fetch release
-tdl update --dry-run                        # report availability only
-tdl update --version(-v) v0.20.4            # install an exact release
-tdl update --force(-f)                      # reinstall / allow downgrade
-tdl update --yes(-y)                        # skip confirmation prompt
-GITHUB_TOKEN=ghp_XXXX tdl update            # use GitHub token to avoid rate limit
-{{< /command >}}
-
-{{< hint info >}}
-Use `tdl update --yes(-y)` to skip the confirmation prompt (e.g. in scripts). The new binary's checksum is verified before replacing the old one. If `tdl` was installed via Homebrew, please use `brew upgrade tdl` instead.
-{{< /hint >}}

--- a/docs/content/en/getting-started/installation.md
+++ b/docs/content/en/getting-started/installation.md
@@ -290,6 +290,7 @@ tdl update --proxy socks5://localhost:1080  # use proxy to fetch release
 tdl update --dry-run                        # report availability only
 tdl update --version(-v) v0.20.4            # install an exact release
 tdl update --force(-f)                      # reinstall / allow downgrade
+tdl update --yes(-y)                        # skip confirmation prompt
 GITHUB_TOKEN=ghp_XXXX tdl update            # use GitHub token to avoid rate limit
 {{< /command >}}
 

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -279,6 +279,14 @@ tdl update
 tdl version
 {{< /command >}}
 
+其他选项：
+
+{{< command >}}
+tdl update --check             # 仅检查是否有更新
+tdl update --version v0.20.4   # 安装指定版本
+tdl update --force             # 重新安装 / 允许降级
+{{< /command >}}
+
 {{< hint info >}}
 使用 `tdl update --yes` 跳过确认提示（例如在脚本中）。新二进制文件的校验和会在替换旧文件之前进行验证。如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
 {{< /hint >}}

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -286,9 +286,10 @@ tdl update --proxy socks5://localhost:1080  # 使用代理获取更新
 tdl update --dry-run                        # 仅检查是否有更新
 tdl update --version(-v) v0.20.4            # 安装指定版本
 tdl update --force(-f)                      # 重新安装 / 允许降级
+tdl update --yes(-y)                        # 跳过确认提示
 GITHUB_TOKEN=ghp_XXXX tdl update            # 使用 GitHub 令牌避免 API 速率限制
 {{< /command >}}
 
 {{< hint info >}}
-使用 `tdl update --yes(-y)` 跳过确认提示（例如在脚本中）。新二进制文件的校验和会在替换旧文件之前进行验证。如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
+如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
 {{< /hint >}}

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -282,11 +282,13 @@ tdl version
 其他选项：
 
 {{< command >}}
-tdl update --check             # 仅检查是否有更新
-tdl update --version v0.20.4   # 安装指定版本
-tdl update --force             # 重新安装 / 允许降级
+tdl update --proxy socks5://localhost:1080  # 使用代理获取更新
+tdl update --dry-run                        # 仅检查是否有更新
+tdl update --version(-v) v0.20.4            # 安装指定版本
+tdl update --force(-f)                      # 重新安装 / 允许降级
+GITHUB_TOKEN=ghp_XXXX tdl update            # 使用 GitHub 令牌避免 API 速率限制
 {{< /command >}}
 
 {{< hint info >}}
-使用 `tdl update --yes` 跳过确认提示（例如在脚本中）。新二进制文件的校验和会在替换旧文件之前进行验证。如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
+使用 `tdl update --yes(-y)` 跳过确认提示（例如在脚本中）。新二进制文件的校验和会在替换旧文件之前进行验证。如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
 {{< /hint >}}

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -59,6 +59,30 @@ curl -sSL https://docs.iyear.me/tdl/install.sh | sudo bash -s -- --version VERSI
 {{< /tab >}}
 {{< /tabs >}}
 
+### 更新
+
+`tdl` 可以自动更新到最新版本：
+
+{{< command >}}
+tdl update
+tdl version
+{{< /command >}}
+
+其他选项：
+
+{{< command >}}
+tdl update --proxy socks5://localhost:1080  # 使用代理获取更新
+tdl update --dry-run                        # 仅检查是否有更新
+tdl update --version(-v) v0.20.4            # 安装指定版本
+tdl update --force(-f)                      # 重新安装 / 允许降级
+tdl update --yes(-y)                        # 跳过确认提示
+GITHUB_TOKEN=ghp_XXXX tdl update            # 使用 GitHub 令牌避免 API 速率限制
+{{< /command >}}
+
+{{< hint info >}}
+如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
+{{< /hint >}}
+
 ## 包管理器
 
 {{< tabs "package managers" >}}
@@ -269,27 +293,3 @@ go1.21.13 linux/amd64
 go install github.com/iyear/tdl@latest
 tdl version
 {{< /command >}}
-
-## 更新
-
-`tdl` 可以自动更新到最新版本：
-
-{{< command >}}
-tdl update
-tdl version
-{{< /command >}}
-
-其他选项：
-
-{{< command >}}
-tdl update --proxy socks5://localhost:1080  # 使用代理获取更新
-tdl update --dry-run                        # 仅检查是否有更新
-tdl update --version(-v) v0.20.4            # 安装指定版本
-tdl update --force(-f)                      # 重新安装 / 允许降级
-tdl update --yes(-y)                        # 跳过确认提示
-GITHUB_TOKEN=ghp_XXXX tdl update            # 使用 GitHub 令牌避免 API 速率限制
-{{< /command >}}
-
-{{< hint info >}}
-如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
-{{< /hint >}}

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -61,7 +61,7 @@ curl -sSL https://docs.iyear.me/tdl/install.sh | sudo bash -s -- --version VERSI
 
 ### 更新
 
-`tdl` 可以自动更新到最新版本：
+`tdl` 可以自动更新到最新版本(管理员/root权限)
 
 {{< command >}}
 tdl update

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -269,3 +269,16 @@ go1.21.13 linux/amd64
 go install github.com/iyear/tdl@latest
 tdl version
 {{< /command >}}
+
+## 更新
+
+`tdl` 可以自动更新到最新版本：
+
+{{< command >}}
+tdl update
+tdl version
+{{< /command >}}
+
+{{< hint info >}}
+使用 `tdl update --yes` 跳过确认提示（例如在脚本中）。新二进制文件的校验和会在替换旧文件之前进行验证。如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
+{{< /hint >}}

--- a/docs/content/zh/getting-started/installation.md
+++ b/docs/content/zh/getting-started/installation.md
@@ -80,7 +80,7 @@ GITHUB_TOKEN=ghp_XXXX tdl update            # 使用 GitHub 令牌避免 API 速
 {{< /command >}}
 
 {{< hint info >}}
-如果 `tdl` 是通过 Homebrew 安装的，请使用 `brew upgrade tdl`。
+如果 `tdl` 是通过包管理器/Docker 安装的，请使用相应的包管理器/镜像更新 `tdl`。
 {{< /hint >}}
 
 ## 包管理器

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/iyear/tdl
 go 1.25.8
 
 require (
+	atomicgo.dev/isadmin v1.1.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bcicen/jstream v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.8
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bcicen/jstream v1.0.1
 	github.com/beevik/ntp v1.5.0
 	github.com/expr-lang/expr v1.17.8
@@ -47,7 +48,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+atomicgo.dev/isadmin v1.1.1 h1:HTIMXfiZQE/dhONi+VfQGRFSwVrdTHuMFSJsd/EdIyY=
+atomicgo.dev/isadmin v1.1.1/go.mod h1:AX/qhBqlxTdpjvrxL2t+sAJ+bDU5ADpJkfUSdvV6qpk=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
@@ -274,6 +276,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
## Proposal

Adds a `tdl update` command for self-updating the binary to the latest GitHub release.

```bash
tdl update                     # interactive
tdl update --yes               # non-interactive (scripts)
tdl update --check             # report availability only, no download
tdl update --version v0.20.4   # install an exact release
tdl update --force             # reinstall / allow downgrade
```

## Behavior

- Fetches the latest release via the GitHub API (`go-github`, already a dependency) and compares tags with the current version using semver. Dev builds (unparseable version) can always update.
- Downloads the asset matching `GOOS`/`GOARCH`/`GOARM` following the goreleaser naming scheme (`tdl_Linux_64bit.tar.gz`, `tdl_Windows_armv6.zip`, ...). GOARM is read from build info with a safe fallback.
- **Verifies sha256** of the archive against the published `tdl_checksums.txt` before touching anything.
- Atomically replaces the current executable: rename on unix, backup+rollback as `<binary>.old` on Windows.
- Detects Homebrew installations (`/Cellar/` path) and points users to `brew upgrade tdl`.
- Confirmation prompt via survey unless `--yes`.

## Verification

- [x] `go build`, `go vet`, `gofmt`, `golangci-lint` (touched packages): clean
- [x] `go test -race ./app/update/...`: green — unit tests cover asset-name mapping against the **real release asset list**, checksum parsing (incl. binary-mode `*` marker and invalid lines), version comparison edge cases
- [x] `--check` and `--version <tag>` smoke-tested live against real releases
- [x] End-to-end smoke test: dev binary self-updated to real `v0.20.4` from upstream releases, checksum verified, replaced binary runs and reports the new version; re-running reports "already using the latest version"
- [x] Windows replacement path: self-replace of a running `.exe` tested on real hardware (Windows amd64, Go 1.25.8) — backup/rollback dance succeeded, archive sha256 verified against `tdl_checksums.txt` before replacing, updated binary runs and reports the new version

## Relationship with install scripts

The `install.sh`/`install.ps1` scripts remain the recommended way for the **first install** (and manual upgrades). This command is the in-place upgrade path: unlike re-running the script it does not require `sudo`/root, works on Windows without bash, respects `HTTPS_PROXY` natively, and verifies the checksum before replacing anything. It also refuses to touch Homebrew-managed installations.

## Follow-up proposal: signed releases

`checksums.txt` verification protects against corrupted downloads, but not against a compromised release being published with a matching checksums file. Would you be open to enabling [goreleaser cosign keyless signing](https://goreleaser.com/customization/sign/) for the checksums file (`.sig`/`.pem`, certificate identity bound to this repo's release workflow)? With signed releases in place I'd be happy to follow up with a PR that makes `tdl update` verify the signature fail-closed.

## Notes

- The CLI reference pages are auto-generated from cobra, so `update` appears there automatically.
- Docs: "Update" section added to EN/ZH installation guide.