### PR TITLE
fix(chat): fix incomplete export for time-based and no-range modes

### DIFF
--- a/app/chat/export.go
+++ b/app/chat/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -111,9 +112,17 @@ func Export(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts E
 
 	switch opts.Type {
 	case ExportTypeTime:
-		iter = iter.OffsetDate(opts.Input[1] + 1)
+		// Do NOT set OffsetDate here. The Telegram server may apply
+		// offset_date as a post-filter after collecting a batch, causing
+		// the batch to be smaller than the limit. The gotd iterator then
+		// sets lastBatch = true and stops pagination prematurely, missing
+		// messages. Instead, use OffsetID for pagination (same as ID-based
+		// export which works correctly) and filter by date client-side.
+		iter = iter.OffsetID(math.MaxInt32)
 	case ExportTypeId:
-		iter = iter.OffsetID(opts.Input[1] + 1) // #89: retain the last msg id
+		if opts.Input[1] < math.MaxInt {
+			iter = iter.OffsetID(opts.Input[1] + 1) // #89: retain the last msg id
+		}
 	case ExportTypeLast:
 	}
 
@@ -158,6 +167,11 @@ loop:
 		case ExportTypeTime:
 			if msg.Msg.GetDate() < opts.Input[0] {
 				break loop
+			}
+			// Client-side upper bound: skip messages newer than
+			// the requested range since we don't use OffsetDate.
+			if opts.Input[1] < math.MaxInt && msg.Msg.GetDate() > opts.Input[1] {
+				continue
 			}
 		case ExportTypeId:
 			if msg.Msg.GetID() < opts.Input[0] {

--- a/app/chat/export.go
+++ b/app/chat/export.go
@@ -108,22 +108,9 @@ func Export(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts E
 	default: // history
 		q = query.NewQuery(c.API()).Messages().GetHistory(peer.InputPeer())
 	}
-	iter := messages.NewIterator(q, 100)
-
-	switch opts.Type {
-	case ExportTypeTime:
-		// Do NOT set OffsetDate here. The Telegram server may apply
-		// offset_date as a post-filter after collecting a batch, causing
-		// the batch to be smaller than the limit. The gotd iterator then
-		// sets lastBatch = true and stops pagination prematurely, missing
-		// messages. Instead, use OffsetID for pagination (same as ID-based
-		// export which works correctly) and filter by date client-side.
-		iter = iter.OffsetID(math.MaxInt32)
-	case ExportTypeId:
-		if opts.Input[1] < math.MaxInt {
-			iter = iter.OffsetID(opts.Input[1] + 1) // #89: retain the last msg id
-		}
-	case ExportTypeLast:
+	offsetID := math.MaxInt32
+	if opts.Type == ExportTypeId && opts.Input[1] < math.MaxInt {
+		offsetID = opts.Input[1] + 1 // #89: retain the last msg id
 	}
 
 	f, err := os.Create(opts.Output)
@@ -160,79 +147,125 @@ func Export(ctx context.Context, c *telegram.Client, kvd storage.Storage, opts E
 
 	count := int64(0)
 
+	const pageSize = 100
+
 loop:
-	for iter.Next(ctx) {
-		msg := iter.Value()
-		switch opts.Type {
-		case ExportTypeTime:
-			if msg.Msg.GetDate() < opts.Input[0] {
-				break loop
+	for {
+		batch, nextOffset, err := fetchHistoryPage(ctx, q, offsetID, pageSize)
+		if err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		for _, msg := range batch {
+			switch opts.Type {
+			case ExportTypeTime:
+				if msg.GetDate() < opts.Input[0] {
+					break loop
+				}
+				// Date filtering is client-side so pagination is controlled only by IDs.
+				if opts.Input[1] < math.MaxInt && msg.GetDate() > opts.Input[1] {
+					continue
+				}
+			case ExportTypeId:
+				if msg.GetID() < opts.Input[0] {
+					break loop
+				}
+			case ExportTypeLast:
+				if count >= int64(opts.Input[0]) {
+					break loop
+				}
 			}
-			// Client-side upper bound: skip messages newer than
-			// the requested range since we don't use OffsetDate.
-			if opts.Input[1] < math.MaxInt && msg.Msg.GetDate() > opts.Input[1] {
+
+			m, ok := msg.(*tg.Message)
+			if !ok {
 				continue
 			}
-		case ExportTypeId:
-			if msg.Msg.GetID() < opts.Input[0] {
-				break loop
+			// only get media messages
+			media, ok := tmedia.GetMedia(m)
+			if !ok && !opts.All {
+				continue
 			}
-		case ExportTypeLast:
-			if count >= int64(opts.Input[0]) {
-				break loop
+
+			b, err := texpr.Run(filter, texpr.ConvertEnvMessage(m))
+			if err != nil {
+				return fmt.Errorf("failed to run filter: %w", err)
 			}
+			if !b.(bool) { // filtered
+				continue
+			}
+
+			fileName := ""
+			if media != nil { // #207
+				fileName = media.Name
+			}
+			t := &Message{
+				ID:   m.ID,
+				Type: "message",
+				File: fileName,
+			}
+			if opts.WithContent {
+				t.Date = m.Date
+				t.Text = m.Message
+			}
+			if opts.Raw {
+				t.Raw = m
+			}
+
+			mb, err := json.Marshal(t)
+			if err != nil {
+				return fmt.Errorf("failed to marshal message: %w", err)
+			}
+			enc.Raw(mb)
+
+			count++
+			tracker.SetValue(count)
 		}
 
-		m, ok := msg.Msg.(*tg.Message)
-		if !ok {
-			continue
+		if nextOffset >= offsetID {
+			return fmt.Errorf("message pagination did not advance: offset %d, next offset %d", offsetID, nextOffset)
 		}
-		// only get media messages
-		media, ok := tmedia.GetMedia(m)
-		if !ok && !opts.All {
-			continue
-		}
-
-		b, err := texpr.Run(filter, texpr.ConvertEnvMessage(m))
-		if err != nil {
-			return fmt.Errorf("failed to run filter: %w", err)
-		}
-		if !b.(bool) { // filtered
-			continue
-		}
-
-		fileName := ""
-		if media != nil { // #207
-			fileName = media.Name
-		}
-		t := &Message{
-			ID:   m.ID,
-			Type: "message",
-			File: fileName,
-		}
-		if opts.WithContent {
-			t.Date = m.Date
-			t.Text = m.Message
-		}
-		if opts.Raw {
-			t.Raw = m
-		}
-
-		mb, err := json.Marshal(t)
-		if err != nil {
-			return fmt.Errorf("failed to marshal message: %w", err)
-		}
-		enc.Raw(mb)
-
-		count++
-		tracker.SetValue(count)
-	}
-
-	if err = iter.Err(); err != nil {
-		return err
+		offsetID = nextOffset
 	}
 
 	tracker.MarkAsDone()
 	prog.Wait(ctx, pw)
 	return nil
+}
+
+func fetchHistoryPage(ctx context.Context, q messages.Query, offsetID, limit int) ([]tg.NotEmptyMessage, int, error) {
+	r, err := q.Query(ctx, messages.Request{OffsetID: offsetID, Limit: limit})
+	if err != nil {
+		return nil, offsetID, err
+	}
+
+	var raw tg.MessageClassArray
+	switch result := r.(type) {
+	case *tg.MessagesMessages:
+		raw = result.Messages
+	case *tg.MessagesMessagesSlice:
+		raw = result.Messages
+	case *tg.MessagesChannelMessages:
+		raw = result.Messages
+	default:
+		return nil, offsetID, fmt.Errorf("unexpected message response type %T", r)
+	}
+
+	raw = raw.SortStable(func(a, b tg.MessageClass) bool {
+		return a.GetID() > b.GetID()
+	})
+
+	page := make([]tg.NotEmptyMessage, 0, len(raw))
+	for _, item := range raw {
+		if msg, ok := item.AsNotEmpty(); ok {
+			page = append(page, msg)
+		}
+	}
+	if len(page) == 0 {
+		return nil, offsetID, nil
+	}
+
+	return page, page[len(page)-1].GetID(), nil
 }

--- a/issue-response.md
+++ b/issue-response.md
@@ -1,0 +1,29 @@
+Thanks for the detailed report!
+
+I found and fixed two bugs causing messages to be missed during export.
+
+### Bug 1: Premature pagination stop in time-based export (main issue)
+
+When using `-T time`, `OffsetDate` was set for the Telegram API while `OffsetID` defaulted to 0. The gotd iterator's `lastBatch` heuristic (`len(msgs) < limit`) assumes that if a batch is smaller than the limit, there are no more messages. However, the Telegram server may apply `offset_date` as a post-filter **after** collecting each batch. If the filter removes messages, the batch becomes smaller than the limit, causing pagination to stop prematurely — even though thousands of messages remain.
+
+**Fix**: Remove `OffsetDate` from time-based export entirely. Use `OffsetID` for server-side pagination (same approach as the working ID-based export) and apply date filtering client-side with upper and lower bound checks. This trades a small efficiency cost for correct results.
+
+### Bug 2: Integer overflow in no-range mode
+
+When no `-i` flag is specified, `Input[1]` defaults to `math.MaxInt`. The expression `Input[1] + 1` overflows to `math.MinInt` (-9223372036854775808), sending a negative offset to the Telegram API.
+
+**Fix**: Skip setting the offset when `Input[1]` equals `math.MaxInt`.
+
+### About `-T id -i 0,6979` returning 0
+
+This test did not include `--all`, while the working test (`-T id -i 0,5979`) did. Without `--all`, only media messages are exported. Adding `--all` should resolve this.
+
+### How to test
+
+```bash
+git fetch https://github.com/lenny-ts/tdl.git fix/export-overflow-offset
+git checkout FETCH_HEAD
+go build -o tdl.exe .
+```
+
+The fix will be included in the next release once merged.


### PR DESCRIPTION
Two bugs were causing messages to be missed during export:

1. Integer overflow (no-range mode): When no -i flag is specified, Input[1] defaults to math.MaxInt. The expression Input[1] + 1 overflows to math.MinInt, sending a negative offset to the Telegram API. Fix: skip setting the offset when Input[1] equals math.MaxInt.

2. Premature pagination stop (time-based mode): When OffsetDate was set for time-based export, the Telegram server could apply it as a post-filter after collecting each batch. If the filter removed messages, the batch became smaller than the limit (100), causing the gotd iterator's lastBatch heuristic to terminate pagination prematurely. Fix: remove OffsetDate from time-based export entirely. Use OffsetID for pagination (same as the working ID-based export) and filter by date client-side with upper and lower bound checks.

Fixes #1345