### PR TITLE
fix(upload): restore sidecar thumbnails

### DIFF
--- a/app/up/iter.go
+++ b/app/up/iter.go
@@ -237,15 +237,7 @@ func (i *iter) resolveThumb(path string) (*uploaderFile, error) {
 		return nil, errors.Wrapf(err, "invalid thumbnail file: %v", path)
 	}
 
-	thumb, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrap(err, "open thumbnail file")
-	}
-
-	return &uploaderFile{
-		File: thumb,
-		size: 0,
-	}, nil
+	return i.resolveFile(path)
 }
 
 func (i *iter) Value() uploader.Elem {

--- a/app/up/iter_test.go
+++ b/app/up/iter_test.go
@@ -1,0 +1,29 @@
+package up
+
+import (
+	"image"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveThumbUsesFileSize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "video.thumb")
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(f, image.NewRGBA(image.Rect(0, 0, 1, 1)), nil))
+	require.NoError(t, f.Close())
+
+	stat, err := os.Stat(path)
+	require.NoError(t, err)
+
+	thumb, err := (&iter{}).resolveThumb(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, thumb.Close()) })
+
+	require.Equal(t, stat.Size(), thumb.Size())
+}

--- a/app/up/walk.go
+++ b/app/up/walk.go
@@ -36,7 +36,7 @@ func walk(paths, includes, excludes []string) ([]*File, error) {
 			}
 
 			f := File{File: path}
-			t := strings.TrimRight(path, filepath.Ext(path)) + consts.UploadThumbExt
+			t := strings.TrimSuffix(path, filepath.Ext(path)) + consts.UploadThumbExt
 			if fsutil.PathExists(t) {
 				f.Thumb = t
 			}

--- a/app/up/walk_test.go
+++ b/app/up/walk_test.go
@@ -1,0 +1,22 @@
+package up
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalkPairsThumbnailWithoutTrimmingFilenameCharacters(t *testing.T) {
+	dir := t.TempDir()
+	video := filepath.Join(dir, "clip4.mp4")
+	thumb := filepath.Join(dir, "clip4.thumb")
+
+	require.NoError(t, os.WriteFile(video, nil, 0o600))
+	require.NoError(t, os.WriteFile(thumb, nil, 0o600))
+
+	files, err := walk([]string{dir}, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, []*File{{File: video, Thumb: thumb}}, files)
+}

--- a/core/uploader/uploader.go
+++ b/core/uploader/uploader.go
@@ -13,8 +13,10 @@ import (
 	"github.com/gotd/td/telegram/uploader"
 	"github.com/gotd/td/tg"
 	"github.com/samber/lo"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/iyear/tdl/core/logctx"
 	"github.com/iyear/tdl/core/util/fsutil"
 	"github.com/iyear/tdl/core/util/mediautil"
 )
@@ -108,10 +110,14 @@ func (u *Uploader) upload(ctx context.Context, elem Elem) error {
 	})
 
 	doc := message.UploadedDocument(f, caption).MIME(mime.String()).Filename(elem.File().Name())
-	// upload thumbnail TODO(iyear): maybe still unavailable
+	// Telegram accepts thumbnails as InputFile, not InputFileBig. Provide the
+	// known size so gotd uses its small-file upload path.
 	if thumb, ok := elem.Thumb(); ok {
-		if thumbFile, err := uploader.NewUploader(u.opts.Client).
-			FromReader(ctx, thumb.Name(), thumb); err == nil {
+		thumbFile, err := uploader.NewUploader(u.opts.Client).
+			Upload(ctx, uploader.NewUpload(thumb.Name(), thumb, thumb.Size()))
+		if err != nil {
+			logctx.From(ctx).Warn("upload thumbnail", zap.String("thumb", thumb.Name()), zap.Error(err))
+		} else {
 			doc = doc.Thumb(thumbFile)
 		}
 	}


### PR DESCRIPTION
## What changed

- stat an existing `.thumb` sidecar and upload it with its actual size
- use the small-file `InputFile` path required by Telegram document thumbnails
- preserve filename stems when pairing sidecars (for example, `clip4.mp4` now resolves `clip4.thumb`)
- log an optional thumbnail upload failure without failing the main upload
- add focused regression tests for thumbnail size and sidecar pairing

## Why

`uploader.FromReader` does not know the total size. gotd therefore treats the thumbnail as a streamed large upload and returns `InputFileBig`, while `inputMediaUploadedDocument.thumb` expects a regular `InputFile`. Telegram accepts the main video but silently ignores that thumbnail.

This matches the regression reported in #799: sidecars worked in tdl v0.17.4 and stopped after the gotd upgrade in v0.17.5. The small-file path was manually verified with a 22 MB MP4 in Saved Messages: the upload had no thumbnails before and `i`/`m` 320x180 thumbnails afterward. This cleaned-up change additionally carries the real stat size instead of relying on a zero-size branch detail.

## Verification

- `go build`
- `go test -v $(go list ./... | grep -v /test)`
- `golangci-lint v2.6.0` in `.`, `core`, and `extension`
- `go test -race ./app/up`
